### PR TITLE
chore(deps): typescript 6 + group peer-coupled Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,19 @@
 # Pairs with the CI `security` job (pip-audit + npm audit): Dependabot proposes the
 # bumps, CI proves they still pass.
 #
-# Grouping strategy: each group bundles only minor + patch updates (the low-risk,
-# usually-safe bumps, incl. most security fixes) into a single weekly PR. Major
-# updates are deliberately left OUT of the groups, so each breaking major arrives
-# as its own individual PR that can be reviewed and tested on its own — this keeps
-# a security patch (e.g. vite 6.x) from riding in with an untested framework major
-# (e.g. React 19).
+# Grouping strategy: each catch-all group bundles only minor + patch updates (the
+# low-risk, usually-safe bumps, incl. most security fixes) into a single weekly PR.
+# Major updates are deliberately left OUT of those groups, so each breaking major
+# arrives as its own individual PR that can be reviewed and tested on its own — this
+# keeps a security patch (e.g. vite 6.x) from riding in with an untested framework
+# major (e.g. React 19).
+#
+# The exception is packages coupled by peer dependencies: react/react-dom,
+# vite/@vitejs/*, i18next/react-i18next. Bumping one across a major without the
+# other fails `npm ci` with ERESOLVE, so a solo PR for either half can never go
+# green. Those families are grouped ahead of the catch-all with no `update-types`
+# filter, which makes them move as one unit at every version level. Groups are
+# matched top-down, so a coupled family always claims its packages first.
 version: 2
 updates:
   - package-ecosystem: pip
@@ -24,8 +31,18 @@ updates:
     directory: /frontend
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    # Raised from 5: the coupled-major PRs below need headroom, and hitting the cap
+    # silently stops Dependabot opening the companion half of a pair.
+    open-pull-requests-limit: 10
     groups:
+      # i18n first: `react-i18next` belongs here, not with the react runtime.
+      i18n:
+        patterns: ["i18next", "react-i18next"]
+      react:
+        patterns:
+          ["react", "react-dom", "@types/react", "@types/react-dom"]
+      vite:
+        patterns: ["vite", "@vitejs/*"]
       frontend:
         patterns: ["*"]
         update-types: ["minor", "patch"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
-        "typescript": "^5.5.4",
+        "typescript": "^6.0.3",
         "vite": "^6.4.3"
       }
     },
@@ -1823,9 +1823,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
-    "typescript": "^5.5.4",
+    "typescript": "^6.0.3",
     "vite": "^6.4.3"
   }
 }


### PR DESCRIPTION
Handles the first slice of the open Dependabot backlog (#1–#5).

## TypeScript 5.9.3 → 6.0.3 (supersedes #1)

Redone on current `main` rather than merging `dependabot/npm_and_yarn/frontend/typescript-6.0.3`. That branch was **62 commits behind** and predated the `tsconfig.json` change and the `node --test` harness, so its green CI run said nothing about today's tree. Reinstalling here also regenerates the lockfile against the current dependency graph.

Verified locally against this branch:

- `tsc --noEmit` clean on TypeScript 6.0.3
- `vite build` succeeds (82 modules transformed)
- 18/18 frontend tests pass
- `npm audit --omit=dev --audit-level=high` → 0 vulnerabilities

## Dependabot: group peer-coupled packages

Four of the five open Dependabot PRs (#2, #3, #4, #5) fail CI with the identical error — `npm ERESOLVE`. None are bad upgrades; each is one half of a peer-coupled pair, and no solo half can ever install:

| PR | Bumps | Blocked by |
|----|-------|-----------|
| #2 | `react-dom` 19, `@types/react-dom` 19 | `react`/`@types/react` still 18 |
| #3 | `vite` 8 | `@vitejs/plugin-react` 4 peers on vite ≤7 |
| #5 | `@vitejs/plugin-react` 6 | peers on `vite ^8`, we pin 6 |
| #4 | `react-i18next` 17 | peers on `i18next >= 26.2.0`, we pin `^23` |

Root cause is config, not luck. Majors were deliberately excluded from the groups — sound intent, but it guarantees ERESOLVE for families that must move together. Compounding it, `open-pull-requests-limit: 5` was **exactly hit**, which is very likely why the companion `react` and `i18next` PRs were never opened at all.

This groups `i18next`/`react-i18next`, `react`/`react-dom`/`@types/*`, and `vite`/`@vitejs/*` ahead of the catch-all with no `update-types` filter, so each family moves as one unit. The catch-all keeps its minor+patch scope, so the original guarantee — a security patch never rides in with an untested framework major — still holds. Limit raised to 10.

The failing `Security (image scan)` checks on #2–#5 are the same `npm ci` failing inside the Docker build, not a real vulnerability. `Security (dependency audit)` passes on all five: **nothing in this backlog is a security fix.**

## Follow-up

Once this lands, #2–#5 can be closed and Dependabot will re-open them as grouped `vite`, `react`, and `i18n` PRs — each carrying both halves of its pair, based on fresh `main`. Those can actually go green, which the current ones cannot. That also serves as a live check that the new grouping behaves as intended.
