### PR TITLE
fix(docker): build the SPA on node 24 to match CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The Node major selects the bundled npm (22 -> npm 10, 24 -> npm 11), and those npm
+  # majors disagree on whether a violated *optional* peer dependency is fatal. If the
+  # image builds the SPA on a different major than CI validates it on, `npm ci` can pass
+  # every job here and still fail `docker build` on the same lockfile. Fail on drift
+  # rather than trusting the "keep in sync" comment in the Dockerfile.
+  toolchain:
+    name: Toolchain (node parity)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Dockerfile node major matches ci.yml node-version
+        run: |
+          set -euo pipefail
+          # `|| true`: a no-match grep exits 1, which under `set -e` would abort the
+          # step before the explicit error below could explain what went wrong.
+          docker_major="$(grep -oP '^FROM node:\K[0-9]+' Dockerfile | sort -u || true)"
+          ci_major="$(grep -oP 'node-version:\s*"\K[0-9]+' .github/workflows/ci.yml | sort -u || true)"
+
+          echo "Dockerfile: ${docker_major:-<none found>}"
+          echo "ci.yml:     ${ci_major:-<none found>}"
+
+          if [ -z "$docker_major" ] || [ -z "$ci_major" ]; then
+            echo "::error::could not parse a node major — did the FROM or node-version syntax change?"
+            exit 1
+          fi
+          if [ "$(printf '%s\n' "$docker_major" | wc -l)" -ne 1 ] \
+            || [ "$(printf '%s\n' "$ci_major" | wc -l)" -ne 1 ]; then
+            echo "::error::more than one distinct node major declared; unify them first"
+            exit 1
+          fi
+          if [ "$docker_major" != "$ci_major" ]; then
+            echo "::error::node major drift — Dockerfile is on $docker_major, ci.yml on $ci_major"
+            exit 1
+          fi
+          echo "OK — both build the SPA on node $docker_major"
+
   backend:
     name: Backend (ruff + pytest)
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,13 @@
 # --- Stage 1: build the SPA (Vite -> dist) -----------------------------------
 # Debian (not alpine/musl) to avoid esbuild native-binary edge cases; this stage is
 # discarded, so it doesn't affect the final image size.
-FROM node:22-slim AS frontend
+#
+# Keep this major in sync with `node-version` in .github/workflows/ci.yml. The Node
+# major picks the bundled npm (22 -> npm 10, 24 -> npm 11), and the two npm majors
+# disagree on whether a violated *optional* peer dependency is fatal. With CI on 24
+# and this stage on 22, `npm ci` could pass every CI job and still fail the image
+# build on the very same lockfile.
+FROM node:24-slim AS frontend
 WORKDIR /build
 # Install deps first (cached until the lockfile changes), then build.
 COPY frontend/package.json frontend/package-lock.json ./


### PR DESCRIPTION
## The bug

CI validates the frontend on **node 24 → npm 11.16**. The shipped image builds it on **`node:22-slim` → npm 10.9.8**.

Those two npm majors disagree about whether a violated *optional* peer dependency is fatal. npm 11 warns; npm 10 fails with `ERESOLVE`.

**Consequence: `npm ci` can pass every CI job and still fail `docker build` on the identical lockfile.** CI was never validating the toolchain that actually ships.

## How it surfaced

#10 (typescript 7). After #7 landed, `i18next@26.3.5` declares:

```
peerDependencies:     { typescript: "^5 || ^6" }
peerDependenciesMeta: { typescript: { optional: true } }
```

TypeScript 7 violates that range. On #10, `Frontend (typecheck + build)` passed and `Security (image scan)` failed — same lockfile, same `npm ci`, different npm.

Reproduced locally on #10's lockfile:

| npm | result |
|---|---|
| 11.13.0 | `npm ci` succeeds |
| 10.x | `npm ci` → `ERESOLVE ... peerOptional typescript@"^5 || ^6" from i18next@26.3.5` |

The image scan happened to catch it here only because that job builds the image. A change that broke `npm ci` without touching the scan would have gone green.

## The fix

Build the SPA on `node:24-slim`, matching `node-version: "24"` in `ci.yml`. Vite 8 requires node `>=22.12`, so 24 is in range, and node 24 is LTS.

## Trade-off, stated plainly

This makes the image build **as lenient as CI** — a violated optional peer no longer stops it. Two environments agreeing matters more than one of them tripping over type-only metadata, so I think this is the right direction. But it does remove the tripwire that surfaced the TypeScript 7 conflict.

Practical effect: **#10 will now go green.** It should still be held — `i18next` and `react-i18next` both still cap typescript at `^6`, and merging would mean shipping against a declared incompatibility that npm 11 merely chooses to tolerate. #10 stays blocked on that reason, not on a red X.

## Verification

Docker's daemon isn't running on my machine, so `docker build` was not exercised locally — the `Security (image scan)` job on this PR is the real check, since it runs `docker build` end to end.

The npm-major behaviour above **was** verified locally against #10's lockfile, and the node→npm mapping was confirmed against the official Node release index (`node v22.23.1 → npm 10.9.8`, `node v24.18.0 → npm 11.16.0`).

## Follow-up worth considering

The Dockerfile now carries a "keep in sync with ci.yml" comment. Comments drift. A one-line CI assertion that the Dockerfile's node major equals `node-version` would make it enforceable — happy to add it here or separately.
