### PR TITLE
release: 0.4.3 — frontend medium-finding remediation (FE-H4, FE-M1..M10)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Joulenap version
       description: Shown in the UI footer.
-      placeholder: "0.4.2"
+      placeholder: "0.4.3"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.3]
+
+### Added
+
+- **Unsaved-changes guard** — editing a settings tab (Localization, Notifications, Backup safety)
+  or the scheduler and then navigating away now asks before discarding the edits, instead of
+  losing them silently. Also warns on a browser tab close or refresh while there are unsaved
+  changes.
+- **Request timeout** — the UI now shows a clear "timed out" message instead of hanging
+  indefinitely if the backend stops responding.
+
+### Fixed
+
+- **Setup wizard validation** — a step no longer completes, and Save no longer unlocks, when a
+  check fails: an unreachable PBS, a missing PBS API token, or an empty Wake-on-LAN MAC now
+  block completion instead of saving a broken configuration.
+- **Setup wizard re-save** — no longer reverts a hand-configured Proxmox VE port or TLS setting.
+- **Manual actions** — Run backup, Run GC, and Power on/off now show the error when they fail to
+  start, instead of appearing to do nothing.
+- **Scheduler toggle** — the Enabled switch now explains why it reverted when the change fails,
+  instead of silently flipping back.
+- **Live task log** — no longer occasionally shows duplicated lines.
+- **Guest list** — keeps the last-known guests (with an error note) when a refresh fails, rather
+  than blanking to an empty panel. What gets backed up is unaffected: the guest set is resolved
+  live at backup time.
+- **Localization tab** — no longer shows a "Saved" note before anything was saved, and its
+  fields resync if the configuration changes underneath.
+- **Integrations copy** — corrected contradictory text about regenerating the API key.
+  Regenerating replaces the key and the old one stops working immediately.
+
 ## [0.4.2]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Joulenap **owns the schedule** itself (internal scheduler), so nothing on the Pr
 
 ## Status
 
-**v0.4.2.** Feature-complete: scheduler + Wake-on-LAN + vzdump + retention + GC + verify +
+**v0.4.3.** Feature-complete: scheduler + Wake-on-LAN + vzdump + retention + GC + verify +
 notifications + setup wizard, packaged as a Docker image — with transport hardening (PBS TLS
 pinning + SSH host-key verification) and auth hardening (login rate-limit, session hardening).
 Includes a read-only [dashboard integration](docs/INTEGRATIONS.md) (Homepage/Homarr/Dashy/Glance),

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 """Joulenap — web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "joulenap"
-version = "0.4.2"
+version = "0.4.3"
 description = "Self-hosted web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."
 readme = "../README.md"
 requires-python = ">=3.12"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joulenap-frontend",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
-import { afterEach, test } from 'node:test'
-import { ApiError, api, setUnauthorizedHandler } from './client.ts'
+import { afterEach, mock, test } from 'node:test'
+import { ApiError, api, setTimeoutMessage, setUnauthorizedHandler } from './client.ts'
 
 // Make every request resolve to the given status, ignoring the URL (req() uses the global
 // fetch). Returns a restore function.
@@ -57,4 +57,27 @@ test('a 401 on /login does NOT trigger the handler (wrong credentials)', async (
   )
   assert.equal(fired, false)
   restore()
+})
+
+test('the backstop timeout aborts a hung request and surfaces a 408 ApiError (FE-M1)', async () => {
+  mock.timers.enable({ apis: ['setTimeout'] })
+  const orig = globalThis.fetch
+  // A backend that never responds on its own — only the abort signal ends the fetch, exactly
+  // as the browser behaves when our AbortController fires.
+  globalThis.fetch = ((_url: string, init: RequestInit) =>
+    new Promise((_resolve, reject) => {
+      init.signal?.addEventListener('abort', () =>
+        reject(new DOMException('The operation was aborted.', 'AbortError')),
+      )
+    })) as typeof fetch
+  setTimeoutMessage('timed out!')
+  const pending = api.status()
+  mock.timers.tick(45000) // advance past DEFAULT_TIMEOUT_MS so the backstop fires
+  await assert.rejects(
+    pending,
+    (e) => e instanceof ApiError && e.status === 408 && e.message === 'timed out!',
+  )
+  globalThis.fetch = orig
+  mock.timers.reset()
+  setTimeoutMessage('The request timed out.')
 })

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -39,13 +39,46 @@ export function setUnauthorizedHandler(fn: (() => void) | null): void {
 // current password on /account (BE-S9) — must NOT eject the user; only a dead session does.
 const AUTH_SELF_HANDLED = new Set(['/login', '/account'])
 
-async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
-  const res = await fetch('/api' + path, {
-    method,
-    credentials: 'same-origin',
-    headers: body !== undefined ? { 'Content-Type': 'application/json' } : undefined,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  })
+// Client-side backstop timeout (ms). Sits *above* the backend's own probe ceilings (the
+// slowest is the 30s httpx connect on wizard PVE/PBS), so it never pre-empts an informative
+// backend error — it only fires when the backend itself stops responding (wedged process, a
+// proxy black-holing the response), turning an indefinite fetch hang into a clean error
+// (FE-M1). Every call is bounded: the long-running backup/GC jobs return a run_id immediately
+// and are polled separately, so no request legitimately runs this long.
+const DEFAULT_TIMEOUT_MS = 45000
+
+// The timeout error text is localized, but this module lives outside React and can't call
+// t() itself, so the app registers the translated string here (mirroring the 401 handler) and
+// re-registers it on a language switch. A plain-English fallback covers the pre-registration
+// window and keeps client.ts usable in tests.
+let timeoutMessage = 'The request timed out.'
+export function setTimeoutMessage(msg: string): void {
+  timeoutMessage = msg
+}
+
+async function req<T>(method: string, path: string, body?: unknown, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<T> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  let res: Response
+  try {
+    res = await fetch('/api' + path, {
+      method,
+      credentials: 'same-origin',
+      headers: body !== undefined ? { 'Content-Type': 'application/json' } : undefined,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    })
+  } catch (e) {
+    // Our own timeout aborts with an AbortError; surface it as an ApiError so callers show it
+    // like any other failure. A caller-initiated abort would look identical, but we don't pass
+    // external signals in yet, so every abort here is the timeout.
+    if (e instanceof DOMException && e.name === 'AbortError') {
+      throw new ApiError(408, timeoutMessage)
+    }
+    throw e
+  } finally {
+    clearTimeout(timer)
+  }
   if (!res.ok) {
     if (res.status === 401 && !AUTH_SELF_HANDLED.has(path.split('?')[0])) {
       onUnauthorized?.()

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
-import { api, setUnauthorizedHandler } from '../api/client'
+import { useTranslation } from 'react-i18next'
+import { api, setTimeoutMessage, setUnauthorizedHandler } from '../api/client'
 
 interface AuthState {
   loading: boolean
@@ -22,6 +23,7 @@ interface AuthContextValue extends AuthState {
 const AuthContext = createContext<AuthContextValue | null>(null)
 
 export function AuthProvider({ children }: { children: ReactNode }) {
+  const { t, i18n } = useTranslation()
   const [state, setState] = useState<AuthState>({
     loading: true,
     authenticated: false,
@@ -54,6 +56,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     )
     return () => setUnauthorizedHandler(null)
   }, [])
+
+  // Hand the API client the localized backstop-timeout message (it lives outside React), and
+  // refresh it whenever the language changes (FE-M1).
+  useEffect(() => {
+    setTimeoutMessage(t('common.requestTimeout'))
+  }, [t, i18n.language])
 
   const login = useCallback(async (username: string, password: string) => {
     const u = await api.login(username, password)

--- a/frontend/src/devStub.ts
+++ b/frontend/src/devStub.ts
@@ -218,7 +218,7 @@ const WIZARD_SSH_TRUST: { trusted: boolean } = { trusted: true }
 const WIZARD_RESET: { ok: boolean } = { ok: true }
 
 const ROUTES: Record<string, unknown> = {
-  'GET /health': { status: 'ok', version: '0.4.2-stub' },
+  'GET /health': { status: 'ok', version: '0.4.3-stub' },
   'GET /auth/status': AUTH_STATUS,
   'GET /auth/me': ME,
   'GET /status': STATUS,

--- a/frontend/src/hooks/useTaskLog.ts
+++ b/frontend/src/hooks/useTaskLog.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api } from '../api/client'
 import type { TaskLogLine } from '../api/types'
+import { appendTaskLines } from '../utils/taskLog'
 
 // Tails GET /api/tasklog for the live "Task log" panel. Polls fast (2s) while a job runs,
 // slow (8s) when idle. Line ids increase globally, so we poll `after` the last id we hold;
@@ -9,8 +10,15 @@ export function useTaskLog(running: boolean) {
   const [lines, setLines] = useState<TaskLogLine[]>([])
   const runIdRef = useRef<number | null>(null)
   const afterRef = useRef(0)
+  // Guard against overlapping polls (a slow response, or the immediate poll on a `running`
+  // change firing before the previous interval tick resolved). Without it two polls issued
+  // with the same `after` both append the same window → duplicate lines/keys (FE-M6). The
+  // idempotent append below is a second line of defence for anything that slips past this.
+  const inFlightRef = useRef(false)
 
   const poll = useCallback(async () => {
+    if (inFlightRef.current) return
+    inFlightRef.current = true
     try {
       const res = await api.taskLog(afterRef.current)
       if (res.run_id === null) return
@@ -24,11 +32,13 @@ export function useTaskLog(running: boolean) {
         return
       }
       if (res.lines.length) {
-        setLines((prev) => [...prev, ...res.lines])
-        afterRef.current = res.lines[res.lines.length - 1].id
+        setLines((prev) => appendTaskLines(prev, res.lines))
+        afterRef.current = Math.max(afterRef.current, res.lines[res.lines.length - 1].id)
       }
     } catch {
       // transient error: keep what we have, retry next tick
+    } finally {
+      inFlightRef.current = false
     }
   }, [])
 

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -7,9 +7,15 @@
     "loading": "Loading…",
     "never": "never",
     "saveFailed": "Couldn't save changes",
+    "requestTimeout": "The request timed out — Joulenap didn't respond in time. Check it is running and try again.",
     "backendUnreachable": "Can't reach Joulenap — showing last known data.",
     "notConfigured": "Joulenap isn't set up yet — connect your Proxmox VE and PBS to start backing up.",
-    "runSetup": "Run setup wizard →"
+    "runSetup": "Run setup wizard →",
+    "unsaved": {
+      "title": "Discard unsaved changes?",
+      "body": "You have edits here that haven't been saved. Leaving now discards them.",
+      "confirm": "Discard changes"
+    }
   },
   "auth": {
     "brand": "Joulenap · Scheduler PBS",
@@ -84,8 +90,10 @@
     "scheduleCustom": "Custom schedule set in config.yaml ({{cron}}) — edit it there to change.",
     "apply": "Apply changes",
     "saved": "✓ Schedule saved",
+    "actionFailed": "Couldn't start the action. Check the PBS and try again.",
     "guests": "Guests",
     "refresh": "Refresh",
+    "guestsError": "Couldn't refresh the guest list — showing the last known guests.",
     "general": "General backup",
     "selective": "Selective backup",
     "selectedCount": "{{n}} sel.",
@@ -333,6 +341,10 @@
         "pbsRoot": "Used once to create the PBS API token and install the shutdown SSH key, then discarded.",
         "sshManual": "Add the line below to /root/.ssh/authorized_keys on the PBS, then mark as installed.",
         "fingerprintPinned": "This fingerprint is pinned — connections are rejected if it changes."
+      },
+      "errors": {
+        "pbsUnreachable": "PBS is not reachable at that host and port. Check it is powered on and the address is correct, then try again.",
+        "pbsTokenMissing": "A PBS API token is required. Enter the token ID and secret before continuing."
       }
     },
     "integrations": {
@@ -349,7 +361,7 @@
       "copyFailed": "Couldn't copy automatically — select the text and copy it manually.",
       "copySnippet": "Copy snippet",
       "snippetHint": "Paste this under a group in your dashboard's config and keep the indentation intact.",
-      "keyHiddenNote": "A key is configured. Regenerate to see a new one; the current key stays valid.",
+      "keyHiddenNote": "A key is configured. Regenerating replaces it — the current key stops working immediately.",
       "dashboardLabel": "Dashboard",
       "snippetLabel": "Configuration snippet",
       "regenerateConfirmTitle": "Regenerate API key?",

--- a/frontend/src/i18n/it.json
+++ b/frontend/src/i18n/it.json
@@ -7,9 +7,15 @@
     "loading": "Caricamento…",
     "never": "mai",
     "saveFailed": "Impossibile salvare le modifiche",
+    "requestTimeout": "Richiesta scaduta — Joulenap non ha risposto in tempo. Verifica che sia in esecuzione e riprova.",
     "backendUnreachable": "Impossibile raggiungere Joulenap — mostro gli ultimi dati noti.",
     "notConfigured": "Joulenap non è ancora configurato — collega Proxmox VE e PBS per iniziare a fare backup.",
-    "runSetup": "Avvia la configurazione →"
+    "runSetup": "Avvia la configurazione →",
+    "unsaved": {
+      "title": "Ignorare le modifiche non salvate?",
+      "body": "Hai modifiche non ancora salvate qui. Uscendo ora andranno perse.",
+      "confirm": "Ignora le modifiche"
+    }
   },
   "auth": {
     "brand": "Joulenap · Scheduler PBS",
@@ -84,8 +90,10 @@
     "scheduleCustom": "Pianificazione personalizzata impostata in config.yaml ({{cron}}) — modificala lì per cambiarla.",
     "apply": "Applica modifiche",
     "saved": "✓ Pianificazione salvata",
+    "actionFailed": "Impossibile avviare l'azione. Controlla il PBS e riprova.",
     "guests": "Guest",
     "refresh": "Aggiorna",
+    "guestsError": "Impossibile aggiornare l'elenco dei guest — mostro gli ultimi guest noti.",
     "general": "Backup generale",
     "selective": "Backup selettivo",
     "selectedCount": "{{n}} sel.",
@@ -333,6 +341,10 @@
         "pbsRoot": "Usata una sola volta per creare il token API del PBS e installare la chiave SSH di spegnimento, poi scartata.",
         "sshManual": "Aggiungi la riga qui sotto a /root/.ssh/authorized_keys sul PBS, poi segna come installata.",
         "fingerprintPinned": "Questa impronta è bloccata — le connessioni vengono rifiutate se cambia."
+      },
+      "errors": {
+        "pbsUnreachable": "Il PBS non è raggiungibile a quell'host e porta. Verifica che sia acceso e che l'indirizzo sia corretto, poi riprova.",
+        "pbsTokenMissing": "È richiesto un token API del PBS. Inserisci l'ID del token e il segreto prima di continuare."
       }
     },
     "integrations": {
@@ -349,7 +361,7 @@
       "copyFailed": "Copia automatica non riuscita — seleziona il testo e copialo manualmente.",
       "copySnippet": "Copia snippet",
       "snippetHint": "Incolla questo sotto un gruppo nella configurazione della tua dashboard e mantieni l'indentazione intatta.",
-      "keyHiddenNote": "Una chiave è configurata. Rigenerala per vederne una nuova; quella attuale resta valida.",
+      "keyHiddenNote": "Una chiave è configurata. Rigenerandola viene sostituita — quella attuale smette di funzionare immediatamente.",
       "dashboardLabel": "Dashboard",
       "snippetLabel": "Snippet di configurazione",
       "regenerateConfirmTitle": "Rigenerare la chiave API?",

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { ApiError, api } from '../api/client'
 import type { Config, GuestInfo, LogLine, StatusResponse } from '../api/types'
 import { ConfirmModal, type ConfirmState } from '../components/ConfirmModal'
 import { useConfig } from '../config/ConfigContext'
+import { useRegisterDirty } from '../shell/UnsavedGuard'
 import { useTaskLog } from '../hooks/useTaskLog'
 import { buildCron, isAdvancedSchedule, parseCron } from '../utils/cron'
 import { ActivityLog } from './dashboard/ActivityLog'
@@ -57,6 +58,7 @@ export function Dashboard({ status, refreshStatus }: DashboardProps) {
   const [draft, setDraft] = useState<Draft | null>(null)
   const [enabled, setEnabled] = useState(false)
   const [guests, setGuests] = useState<GuestInfo[]>([])
+  const [guestsErr, setGuestsErr] = useState<string | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [logs, setLogs] = useState<LogLine[]>([])
   const [confirm, setConfirm] = useState<ConfirmState | null>(null)
@@ -65,6 +67,14 @@ export function Dashboard({ status, refreshStatus }: DashboardProps) {
   const [busy, setBusy] = useState(false)
   const [savedNote, setSavedNote] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  // Failure of a manual action's *start* (Run backup/GC, Power on/off) — surfaced inline in the
+  // ManualPanel rather than swallowed, since the activity log may not carry a start-time error
+  // (FE-M4). Kept separate from the scheduler `err` so a "Power on failed" isn't shown on the
+  // schedule card.
+  const [actionErr, setActionErr] = useState<string | null>(null)
+  // Failure of the instant "Enabled" scheduler toggle — shown next to the toggle so its silent
+  // revert is explained (FE-M5). Separate from the Apply `err` slot at the bottom of the card.
+  const [toggleErr, setToggleErr] = useState<string | null>(null)
   // "Keep PBS on after the job" choice for the backup/GC confirm dialog. A ref mirrors it so
   // the confirm's onConfirm (captured at setConfirm time) reads the latest value.
   const [keepOn, setKeepOn] = useState(false)
@@ -86,12 +96,16 @@ export function Dashboard({ status, refreshStatus }: DashboardProps) {
     setRefreshing(true)
     try {
       setGuests(await api.guests())
-    } catch {
-      setGuests([])
+      setGuestsErr(null)
+    } catch (e) {
+      // Keep the last-known list (like loadLogs) instead of blanking to an empty "0" panel;
+      // surface the failure too, since guests have no auto-retry timer (FE-M8). The backup
+      // itself never depends on this list — it's resolved live server-side at run time.
+      setGuestsErr(e instanceof ApiError ? e.message : t('dashboard.guestsError'))
     } finally {
       setRefreshing(false)
     }
-  }, [])
+  }, [t])
 
   const loadLogs = useCallback(async () => {
     try {
@@ -132,6 +146,7 @@ export function Dashboard({ status, refreshStatus }: DashboardProps) {
     const norm = (d: Draft) => ({ ...d, selected: [...d.selected].sort((a, b) => a - b) })
     return JSON.stringify(norm(draft)) !== JSON.stringify(norm(original))
   }, [draft, original])
+  useRegisterDirty(dirty)
 
   if (!config || !draft) return null
 
@@ -144,11 +159,13 @@ export function Dashboard({ status, refreshStatus }: DashboardProps) {
   const toggleEnabled = async () => {
     const next = !enabled
     setEnabled(next)
+    setToggleErr(null)
     try {
       await api.toggleScheduler(next)
       refreshStatus()
-    } catch {
+    } catch (e) {
       setEnabled(!next) // revert on failure
+      setToggleErr(e instanceof ApiError ? e.message : t('common.saveFailed'))
     }
   }
 
@@ -217,10 +234,13 @@ export function Dashboard({ status, refreshStatus }: DashboardProps) {
         ? { toggle: { label: t('dashboard.confirm.keepOn'), value: initialKeepOn, onChange: setKeepOn } }
         : {}),
       onConfirm: async () => {
+        setActionErr(null)
         try {
           await fn(keepOnRef.current)
-        } catch {
-          /* surfaced in the activity log / status */
+        } catch (e) {
+          // Start-time failure (e.g. 502 WoL send failed, 409 already running, 500): show it —
+          // the activity log can't be relied on to carry it.
+          setActionErr(e instanceof ApiError ? e.message : t('dashboard.actionFailed'))
         }
         pollAfterAction()
       },
@@ -243,6 +263,7 @@ export function Dashboard({ status, refreshStatus }: DashboardProps) {
       <div className="jn-row-actions">
         <ManualPanel
           status={status}
+          error={actionErr}
           onBackup={() => runAction('backup', (k) => api.runBackup(k), false, '▶')}
           onGc={() => runAction('gc', (k) => api.runGc(k), false, '⟳')}
           onPowerOn={() => runAction('on', () => api.powerOn(), false, '⏻')}
@@ -254,6 +275,7 @@ export function Dashboard({ status, refreshStatus }: DashboardProps) {
       <SchedulerCard
         enabled={enabled}
         onToggleEnabled={toggleEnabled}
+        toggleError={toggleErr}
         draft={draft}
         patch={patch}
         dirty={dirty}
@@ -272,6 +294,7 @@ export function Dashboard({ status, refreshStatus }: DashboardProps) {
           onToggleGuest={toggleGuest}
           onRefresh={loadGuests}
           refreshing={refreshing}
+          error={guestsErr}
         />
         <ActivityLog logs={logs} />
       </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useUnsavedGuard } from '../shell/UnsavedGuard'
 import { c } from '../theme'
 import { Account } from './settings/Account'
 import { BackupSafety } from './settings/BackupSafety'
@@ -21,6 +22,7 @@ const NAV: { key: Tab }[] = [
 
 export function Settings(_props: { onClose: () => void; initialTab?: Tab }) {
   const { t } = useTranslation()
+  const { guard } = useUnsavedGuard()
   // Settings is remounted each time the shell switches to it (unmounted on the main view), so
   // this initial value applies afresh every open — the dashboard's "Run setup wizard" CTA
   // opens straight on the setup tab, while the gear opens Localization as before.
@@ -43,7 +45,7 @@ export function Settings(_props: { onClose: () => void; initialTab?: Tab }) {
             <button
               key={key}
               className="jn-settings-navbtn"
-              onClick={() => setTab(key)}
+              onClick={() => guard(() => setTab(key))}
               style={{
                 background: active ? 'rgba(232,131,15,.1)' : 'transparent',
                 border: `1px solid ${active ? 'rgba(232,131,15,.32)' : 'transparent'}`,

--- a/frontend/src/pages/dashboard/GuestsPanel.tsx
+++ b/frontend/src/pages/dashboard/GuestsPanel.tsx
@@ -13,6 +13,7 @@ interface Props {
   onToggleGuest: (vmid: number) => void
   onRefresh: () => void
   refreshing: boolean
+  error: string | null
 }
 
 function modeBtn(active: boolean): React.CSSProperties {
@@ -30,7 +31,7 @@ function modeBtn(active: boolean): React.CSSProperties {
   }
 }
 
-export function GuestsPanel({ guests, mode, onModeChange, selected, onToggleGuest, onRefresh, refreshing }: Props) {
+export function GuestsPanel({ guests, mode, onModeChange, selected, onToggleGuest, onRefresh, refreshing, error }: Props) {
   const { t } = useTranslation()
   const selective = mode === 'selective'
   // Exclude mode is set in config.yaml and can't be represented by the general/selective
@@ -70,6 +71,12 @@ export function GuestsPanel({ guests, mode, onModeChange, selected, onToggleGues
           <span style={{ display: 'inline-block', animation: refreshing ? 'spin .9s linear infinite' : 'none' }}>⟳</span>
         </button>
       </div>
+
+      {error && (
+        <div role="alert" style={{ padding: '0 18px 12px', fontSize: 11.5, color: c.red, lineHeight: 1.4 }}>
+          {error}
+        </div>
+      )}
 
       <div style={{ padding: '0 18px 12px' }}>
         {excludeMode ? (

--- a/frontend/src/pages/dashboard/ManualPanel.tsx
+++ b/frontend/src/pages/dashboard/ManualPanel.tsx
@@ -4,6 +4,7 @@ import { c, panelStyle } from '../../theme'
 
 interface Props {
   status: StatusResponse | null
+  error: string | null
   onBackup: () => void
   onGc: () => void
   onPowerOn: () => void
@@ -43,7 +44,7 @@ function actionBtn(variant: 'primary' | 'ghost' | 'green' | 'red', enabled: bool
   return { ...base, background: 'transparent', color: c.text, border: '1px solid #3a434d' }
 }
 
-export function ManualPanel({ status, onBackup, onGc, onPowerOn, onPowerOff }: Props) {
+export function ManualPanel({ status, error, onBackup, onGc, onPowerOn, onPowerOff }: Props) {
   const { t } = useTranslation()
   const online = !!status?.pbs_online
   const busy = !!status?.job_running
@@ -78,6 +79,24 @@ export function ManualPanel({ status, onBackup, onGc, onPowerOn, onPowerOff }: P
           </div>
         </div>
       </div>
+      {error && (
+        <div
+          role="alert"
+          style={{
+            marginTop: 14,
+            background: 'rgba(229,103,91,.1)',
+            border: '1px solid rgba(229,103,91,.32)',
+            borderRadius: 8,
+            color: c.red,
+            fontSize: 12.5,
+            lineHeight: 1.5,
+            padding: '9px 12px',
+            wordBreak: 'break-word',
+          }}
+        >
+          {error}
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/dashboard/SchedulerCard.tsx
+++ b/frontend/src/pages/dashboard/SchedulerCard.tsx
@@ -20,6 +20,7 @@ export interface SchedulerDraft {
 interface Props {
   enabled: boolean
   onToggleEnabled: () => void
+  toggleError: string | null
   draft: SchedulerDraft
   patch: (p: Partial<SchedulerDraft>) => void
   dirty: boolean
@@ -54,7 +55,7 @@ const DAY_KEYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as const
 
 const toInt = (v: string) => (v === '' ? 0 : Math.max(0, parseInt(v, 10) || 0))
 
-export function SchedulerCard({ enabled, onToggleEnabled, draft, patch, dirty, onApply, busy, saved, error }: Props) {
+export function SchedulerCard({ enabled, onToggleEnabled, toggleError, draft, patch, dirty, onApply, busy, saved, error }: Props) {
   const { t } = useTranslation()
   const advanced = isAdvancedSchedule({ time: draft.time, days: draft.days, dom: draft.dom, month: draft.month })
 
@@ -69,6 +70,12 @@ export function SchedulerCard({ enabled, onToggleEnabled, draft, patch, dirty, o
           <Toggle on={enabled} onClick={onToggleEnabled} />
         </div>
       </div>
+
+      {toggleError && (
+        <div role="alert" style={{ marginTop: -6, marginBottom: 16, fontSize: 12, color: c.red, textAlign: 'right' }}>
+          {toggleError}
+        </div>
+      )}
 
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 26, alignItems: 'flex-end', marginBottom: 18 }}>
         <label style={{ display: 'block', width: 148 }}>

--- a/frontend/src/pages/settings/BackupSafety.tsx
+++ b/frontend/src/pages/settings/BackupSafety.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { ApiError } from '../../api/client'
 import { Toggle } from '../../components/Toggle'
 import { useConfig } from '../../config/ConfigContext'
+import { useRegisterDirty } from '../../shell/UnsavedGuard'
 import { c, inputStyle, labelStyle, panelStyle, primaryBtn } from '../../theme'
 
 // Backup-safety guardrails. These map to existing backend fields wired into the cycle:
@@ -63,6 +64,7 @@ export function BackupSafety() {
       draft.verify_reverify_days !== v.reverify_days
     )
   }, [config, draft])
+  useRegisterDirty(dirty)
 
   if (!config || !draft) return null
 

--- a/frontend/src/pages/settings/Integrations.tsx
+++ b/frontend/src/pages/settings/Integrations.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, ApiError } from '../../api/client'
 import { ConfirmModal, type ConfirmState } from '../../components/ConfirmModal'
+import { useConfig } from '../../config/ConfigContext'
 import { c, ghostBtn, labelStyle, panelStyle, primaryBtn } from '../../theme'
 import { copyToClipboard } from '../../utils/clipboard'
 
@@ -84,7 +85,7 @@ Fields available: pbs_state, next_run, last_run_status, last_run_time,
 
 export function Integrations() {
   const { t } = useTranslation()
-  const [enabled, setEnabled] = useState(false)
+  const { config, reload } = useConfig()
   const [freshKey, setFreshKey] = useState<string | null>(null)
   const [dash, setDash] = useState<Dashboard>('homepage')
   const [busy, setBusy] = useState(false)
@@ -93,12 +94,10 @@ export function Integrations() {
   const [err, setErr] = useState<string | null>(null)
   const [confirm, setConfirm] = useState<ConfirmState | null>(null)
 
-  useEffect(() => {
-    api
-      .getConfig()
-      .then((cfg) => setEnabled(Boolean(cfg.app.api_key)))
-      .catch(() => setEnabled(false))
-  }, [])
+  // Derive "a key is configured" from the shared config (api_key is redacted to a non-empty
+  // sentinel when set) instead of a standalone fetch, and reload() after mutating it so the
+  // shared cache never goes stale (FE-M10).
+  const enabled = Boolean(config?.app.api_key)
 
   async function doGenerate() {
     setBusy(true)
@@ -106,7 +105,7 @@ export function Integrations() {
     try {
       const { api_key } = await api.generateApiKey()
       setFreshKey(api_key)
-      setEnabled(true)
+      await reload()
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : t('common.saveFailed'))
     } finally {
@@ -120,7 +119,7 @@ export function Integrations() {
     try {
       await api.deleteApiKey()
       setFreshKey(null)
-      setEnabled(false)
+      await reload()
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : t('common.saveFailed'))
     } finally {

--- a/frontend/src/pages/settings/Localization.tsx
+++ b/frontend/src/pages/settings/Localization.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ApiError } from '../../api/client'
 import { Dropdown, type Option } from '../../components/Dropdown'
 import { useConfig } from '../../config/ConfigContext'
+import { useRegisterDirty } from '../../shell/UnsavedGuard'
 import { c, labelStyle, panelStyle, primaryBtn } from '../../theme'
 import { TIMEZONES } from '../../utils/timezones'
 
@@ -19,8 +20,30 @@ export function Localization() {
   const [lang, setLang] = useState(savedLang)
   const [tz, setTz] = useState(savedTz)
   const [busy, setBusy] = useState(false)
+  const [savedNote, setSavedNote] = useState(false)
   const [err, setErr] = useState<string | null>(null)
   const dirty = lang !== savedLang || tz !== savedTz
+  useRegisterDirty(dirty)
+
+  // Resync the editable draft when the saved config changes — after our own save, or an
+  // external reload — mirroring the other settings tabs. Without it the dropdowns and the
+  // dirty check drift from the real config (FE-M7).
+  useEffect(() => {
+    setLang(savedLang)
+    setTz(savedTz)
+  }, [savedLang, savedTz])
+
+  // Clear the "saved" note (and any error) the moment the user edits either field.
+  const onLang = (v: string) => {
+    setLang(v)
+    setSavedNote(false)
+    setErr(null)
+  }
+  const onTz = (v: string) => {
+    setTz(v)
+    setSavedNote(false)
+    setErr(null)
+  }
 
   // Options: "automatic" first, then the curated list. If the saved value is a valid
   // IANA name outside the list (hand-edited config), keep it so saving doesn't drop it.
@@ -36,6 +59,7 @@ export function Localization() {
     setErr(null)
     try {
       await save({ ...config, app: { ...config.app, language: lang, timezone: tz } })
+      setSavedNote(true)
     } catch (e) {
       setErr(e instanceof ApiError ? e.message : t('common.saveFailed'))
     } finally {
@@ -54,12 +78,12 @@ export function Localization() {
 
       <div style={{ maxWidth: 320, marginBottom: 24 }}>
         <span style={labelStyle}>{t('settings.localization.language')}</span>
-        <Dropdown value={lang} options={LANGS} onChange={setLang} />
+        <Dropdown value={lang} options={LANGS} onChange={onLang} />
       </div>
 
       <div style={{ maxWidth: 320, marginBottom: 8 }}>
         <span style={labelStyle}>{t('settings.localization.timezone')}</span>
-        <Dropdown value={tz} options={tzOptions} onChange={setTz} mono />
+        <Dropdown value={tz} options={tzOptions} onChange={onTz} mono />
       </div>
       <span style={{ display: 'block', fontSize: 12, color: c.textDim, lineHeight: 1.5, marginBottom: 24 }}>
         {t('settings.localization.timezoneHint')}
@@ -80,7 +104,7 @@ export function Localization() {
         >
           {t('common.save')}
         </button>
-        {!dirty && !err && <span style={{ fontSize: 12, color: c.green }}>{t('settings.localization.saved')}</span>}
+        {savedNote && !dirty && <span style={{ fontSize: 12, color: c.green }}>{t('settings.localization.saved')}</span>}
         {err && <span style={{ fontSize: 12, color: c.red }}>{err}</span>}
       </div>
     </div>

--- a/frontend/src/pages/settings/Notifications.tsx
+++ b/frontend/src/pages/settings/Notifications.tsx
@@ -4,6 +4,7 @@ import { api, ApiError } from '../../api/client'
 import type { ChannelOutcome, NotificationsConfig } from '../../api/types'
 import { Toggle } from '../../components/Toggle'
 import { useConfig } from '../../config/ConfigContext'
+import { useRegisterDirty } from '../../shell/UnsavedGuard'
 import { c, ghostBtn, inputStyle, labelStyle, panelStyle, primaryBtn } from '../../theme'
 import { channelLabel } from '../../utils/notifyChannels'
 
@@ -38,6 +39,7 @@ export function Notifications() {
     () => !!config && !!draft && JSON.stringify(draft) !== JSON.stringify(config.notifications),
     [config, draft],
   )
+  useRegisterDirty(dirty)
 
   if (!config || !draft) return null
 

--- a/frontend/src/pages/settings/SetupWizard.tsx
+++ b/frontend/src/pages/settings/SetupWizard.tsx
@@ -267,6 +267,9 @@ export function SetupWizard() {
   const rapido = w.mode === 'rapido'
   const doneCount = w.status.filter((s) => s === 'done').length
   const allDone = doneCount === 5
+  // Backstop for FE-H4: never enable Save while any connection check is red, even if every
+  // card is marked done (a red status dot must never coexist with an enabled Save).
+  const canSave = allDone && Object.values(w.checks).every(Boolean)
 
   async function run(key: string, fn: () => Promise<void>) {
     setBusy(key)
@@ -317,7 +320,10 @@ export function SetupWizard() {
     run('pve', async () => {
       const r = await api.wizardPveConnect({
         host: w.pveHost,
-        port: 8006,
+        // Respect a hand-configured PVE port so a custom-port install can re-Connect; the
+        // wizard has no port field yet. TLS stays unverified for the connect test — enabling
+        // verification needs fingerprint pinning, which is BE-S1.
+        port: config?.pve.port ?? 8006,
         verify_tls: false,
         mode: rapido ? 'root' : 'token',
         username: w.pveUser,
@@ -351,6 +357,14 @@ export function SetupWizard() {
     run('pbs', async () => {
       const port = Number(w.pbsPort) || 8007
       const r = await api.wizardPbsCheck(w.pbsHost, port)
+      // wizardPbsCheck returns { reachable:false } rather than throwing, so guard it
+      // explicitly — otherwise the card would complete with the PBS status dot red (FE-H4).
+      // Pin the fingerprint (if newly learned) either way, but bail before provisioning: no
+      // point minting a token against an unreachable PBS.
+      if (!r.reachable) {
+        patch({ pbsFp: w.pbsFp || r.fingerprint || '', checks: { ...w.checks, pbs: false } })
+        throw new Error(t('settings.setup.errors.pbsUnreachable'))
+      }
       // Quick setup: mint a scoped PBS token from the root creds (same ones used to install
       // the SSH key), so the user never pastes a token. Manual mode keeps the typed token.
       let { pbsTokenId, pbsTokenSecret } = w
@@ -366,11 +380,17 @@ export function SetupWizard() {
         pbsTokenId = tok.id
         pbsTokenSecret = tok.secret
       }
+      // Manual mode with an empty token would otherwise complete the card with the token dot
+      // red — require it before advancing.
+      if (!(pbsTokenId && pbsTokenSecret)) {
+        patch({ pbsFp: w.pbsFp || r.fingerprint || '', checks: { ...w.checks, pbs: true, token: false } })
+        throw new Error(t('settings.setup.errors.pbsTokenMissing'))
+      }
       advance(2, {
         pbsFp: w.pbsFp || r.fingerprint || '',
         pbsTokenId,
         pbsTokenSecret,
-        checks: { ...w.checks, pbs: r.reachable, token: !!(pbsTokenId && pbsTokenSecret) },
+        checks: { ...w.checks, pbs: true, token: true },
       })
     })
 
@@ -380,7 +400,12 @@ export function SetupWizard() {
       if (r.mac) patch({ wolMac: r.mac })
     })
 
-  const confirmWol = () => advance(3, { checks: { ...w.checks, wol: true } })
+  // A MAC is required to wake the PBS; without it the WoL step must not complete (FE-H4).
+  // Format is validated backend-side on save (BE-C2), so a non-empty check suffices here.
+  const confirmWol = () => {
+    if (!w.wolMac.trim()) return
+    advance(3, { checks: { ...w.checks, wol: true } })
+  }
 
   const genKey = () =>
     run('key', async () => {
@@ -435,9 +460,10 @@ export function SetupWizard() {
     next.pve = {
       ...next.pve,
       host: w.pveHost,
-      port: 8006,
+      // Deliberately don't set port/verify_tls here: the wizard has no field for them, so the
+      // `...next.pve` spread must preserve whatever's saved (defaults 8006/false on a fresh
+      // install) rather than silently reverting a hand-configured PVE port or TLS (FE-M9).
       node: w.node,
-      verify_tls: false,
       api_token_id: w.tokenId,
       // Mirror the PBS guard below: after a reload the secret isn't rehydrated (w.tokenSecret
       // is ''), and next.pve.api_token_secret is the ***REDACTED*** sentinel from GET /config,
@@ -595,7 +621,7 @@ export function SetupWizard() {
             <button style={ghost} onClick={detectMac}>
               {busy === 'mac' ? t('settings.setup.buttons.detecting') : t('settings.setup.buttons.detectMac')}
             </button>
-            <button style={orangeBtn(true)} onClick={confirmWol}>
+            <button style={orangeBtn(!!w.wolMac.trim())} disabled={!w.wolMac.trim()} onClick={confirmWol}>
               {t('settings.setup.buttons.confirm')}
             </button>
           </div>
@@ -861,7 +887,7 @@ export function SetupWizard() {
           </div>
           <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
             {saved && <span style={{ fontSize: 12, color: c.green }}>{t('settings.setup.saved')}</span>}
-            <button onClick={onSave} disabled={!allDone || busy === 'save'} style={{ ...primaryBtn, padding: '9px 22px', background: allDone ? c.accent : '#1d232b', color: allDone ? c.accentInk : c.textMuted, border: allDone ? 'none' : '1px solid #262d35', cursor: allDone ? 'pointer' : 'not-allowed' }}>
+            <button onClick={onSave} disabled={!canSave || busy === 'save'} style={{ ...primaryBtn, padding: '9px 22px', background: canSave ? c.accent : '#1d232b', color: canSave ? c.accentInk : c.textMuted, border: canSave ? 'none' : '1px solid #262d35', cursor: canSave ? 'pointer' : 'not-allowed' }}>
               {t('settings.setup.save')}
             </button>
           </div>

--- a/frontend/src/shell/AppShell.tsx
+++ b/frontend/src/shell/AppShell.tsx
@@ -11,6 +11,7 @@ import { useStatus } from '../hooks/useStatus'
 import { c } from '../theme'
 import { WizardProvider } from '../wizard/WizardContext'
 import { Header } from './Header'
+import { UnsavedGuardProvider, useUnsavedGuard } from './UnsavedGuard'
 
 type View = 'main' | 'settings'
 
@@ -19,6 +20,7 @@ function ShellInner() {
   const { logout } = useAuth()
   const { config, loading } = useConfig()
   const { status, refresh, stale } = useStatus()
+  const { guard } = useUnsavedGuard()
   const [view, setView] = useState<View>('main')
   const [settingsTab, setSettingsTab] = useState<Tab>('localization')
   const [version, setVersion] = useState('')
@@ -83,7 +85,7 @@ function ShellInner() {
               ⚙ {t('common.notConfigured')}
             </span>
             <button
-              onClick={() => openSettings('setup')}
+              onClick={() => guard(() => openSettings('setup'))}
               style={{
                 background: c.accent,
                 color: c.accentInk,
@@ -104,7 +106,7 @@ function ShellInner() {
           host={config?.pbs.host ?? ''}
           status={status}
           view={view}
-          onToggleView={() => (view === 'main' ? openSettings('localization') : setView('main'))}
+          onToggleView={() => guard(() => (view === 'main' ? openSettings('localization') : setView('main')))}
           onLogout={logout}
         />
         {loading ? (
@@ -137,7 +139,9 @@ export function AppShell() {
   return (
     <ConfigProvider>
       <WizardProvider>
-        <ShellInner />
+        <UnsavedGuardProvider>
+          <ShellInner />
+        </UnsavedGuardProvider>
       </WizardProvider>
     </ConfigProvider>
   )

--- a/frontend/src/shell/UnsavedGuard.tsx
+++ b/frontend/src/shell/UnsavedGuard.tsx
@@ -1,0 +1,90 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ConfirmModal, type ConfirmState } from '../components/ConfirmModal'
+
+// A single-slot "unsaved changes" guard (FE-M2). The one editing surface that's mounted at a
+// time (Dashboard scheduler, or the active Settings tab — never both) registers its dirty
+// state; in-app navigation routes through `guard()`, which asks before discarding a dirty
+// draft instead of unmounting it silently. The setup wizard doesn't participate — its state
+// already survives navigation via WizardProvider.
+type DirtyGetter = () => boolean
+
+interface UnsavedGuardValue {
+  registerDirty: (getter: DirtyGetter | null) => void
+  guard: (action: () => void) => void
+}
+
+const Ctx = createContext<UnsavedGuardValue | null>(null)
+
+export function UnsavedGuardProvider({ children }: { children: ReactNode }) {
+  const { t } = useTranslation()
+  const dirtyRef = useRef<DirtyGetter | null>(null)
+  const [confirm, setConfirm] = useState<ConfirmState | null>(null)
+
+  const registerDirty = useCallback((getter: DirtyGetter | null) => {
+    dirtyRef.current = getter
+  }, [])
+
+  const isDirty = useCallback(() => !!dirtyRef.current?.(), [])
+
+  const guard = useCallback(
+    (action: () => void) => {
+      if (!isDirty()) {
+        action()
+        return
+      }
+      setConfirm({
+        title: t('common.unsaved.title'),
+        message: t('common.unsaved.body'),
+        confirmLabel: t('common.unsaved.confirm'),
+        danger: true,
+        icon: '⚠',
+        onConfirm: () => {
+          // The surface we're leaving is about to unmount; drop its registration now so a
+          // stale getter can't mis-guard the next navigation before its cleanup runs.
+          dirtyRef.current = null
+          action()
+        },
+      })
+    },
+    [isDirty, t],
+  )
+
+  // Also warn on browser tab-close / refresh while a draft is dirty. This is a native browser
+  // prompt (text is not localizable / not shown by modern browsers), unlike the in-app modal.
+  useEffect(() => {
+    const onBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!isDirty()) return
+      e.preventDefault()
+      e.returnValue = ''
+    }
+    window.addEventListener('beforeunload', onBeforeUnload)
+    return () => window.removeEventListener('beforeunload', onBeforeUnload)
+  }, [isDirty])
+
+  return (
+    <Ctx.Provider value={{ registerDirty, guard }}>
+      {children}
+      <ConfirmModal state={confirm} onCancel={() => setConfirm(null)} />
+    </Ctx.Provider>
+  )
+}
+
+export function useUnsavedGuard(): UnsavedGuardValue {
+  const ctx = useContext(Ctx)
+  if (!ctx) throw new Error('useUnsavedGuard must be used within UnsavedGuardProvider')
+  return ctx
+}
+
+// Publish this surface's dirty state to the guard for as long as it's mounted. The registered
+// getter reads a ref so the value stays current without re-registering on every keystroke, and
+// the registration is cleared on unmount.
+export function useRegisterDirty(dirty: boolean): void {
+  const { registerDirty } = useUnsavedGuard()
+  const ref = useRef(dirty)
+  ref.current = dirty
+  useEffect(() => {
+    registerDirty(() => ref.current)
+    return () => registerDirty(null)
+  }, [registerDirty])
+}

--- a/frontend/src/utils/taskLog.test.ts
+++ b/frontend/src/utils/taskLog.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import type { TaskLogLine } from '../api/types.ts'
+import { appendTaskLines } from './taskLog.ts'
+
+const ln = (id: number): TaskLogLine => ({ id, ts: `t${id}`, text: `line ${id}` }) as TaskLogLine
+
+test('appends genuinely new lines', () => {
+  const prev = [ln(1), ln(2)]
+  assert.deepEqual(
+    appendTaskLines(prev, [ln(3), ln(4)]).map((l) => l.id),
+    [1, 2, 3, 4],
+  )
+})
+
+test('a re-delivered window (overlapping poll) adds no duplicates (FE-M6)', () => {
+  const prev = [ln(1), ln(2), ln(3)]
+  // Second overlapping poll returns the same window that was already appended.
+  assert.deepEqual(
+    appendTaskLines(prev, [ln(1), ln(2), ln(3)]).map((l) => l.id),
+    [1, 2, 3],
+  )
+})
+
+test('a partially-overlapping window keeps only the new tail', () => {
+  const prev = [ln(1), ln(2), ln(3)]
+  assert.deepEqual(
+    appendTaskLines(prev, [ln(2), ln(3), ln(4), ln(5)]).map((l) => l.id),
+    [1, 2, 3, 4, 5],
+  )
+})
+
+test('returns the same array reference when there is nothing new (no re-render)', () => {
+  const prev = [ln(1), ln(2)]
+  assert.equal(appendTaskLines(prev, []), prev)
+  assert.equal(appendTaskLines(prev, [ln(1), ln(2)]), prev)
+})

--- a/frontend/src/utils/taskLog.ts
+++ b/frontend/src/utils/taskLog.ts
@@ -1,0 +1,12 @@
+import type { TaskLogLine } from '../api/types'
+
+// Append only genuinely-new lines (id greater than the last one already held) so that two
+// overlapping polls re-delivering the same `after` window can't duplicate lines — and thus
+// duplicate React keys / inflate the line count (FE-M6). Returns the SAME array reference when
+// there's nothing new, so React can bail out of the re-render.
+export function appendTaskLines(prev: TaskLogLine[], incoming: TaskLogLine[]): TaskLogLine[] {
+  if (!incoming.length) return prev
+  const lastId = prev.length ? prev[prev.length - 1].id : -1
+  const fresh = incoming.filter((l) => l.id > lastId)
+  return fresh.length ? [...prev, ...fresh] : prev
+}


### PR DESCRIPTION
Batch remediation of the v0.3.1 re-review's frontend findings, released as 0.4.3.

## Setup wizard
- **FE-H4** — a step no longer completes, and Save no longer unlocks, when a check fails: unreachable PBS, missing PBS API token, or empty Wake-on-LAN MAC now block completion instead of saving a broken config.
- **FE-M9** — re-saving the wizard no longer reverts a hand-configured Proxmox VE port or TLS setting; a custom-port install can re-Connect.

## Dashboard robustness / UX
- **FE-M4** — manual actions (Run backup/GC, Power on/off) surface start failures inline instead of appearing to do nothing.
- **FE-M5** — the scheduler Enabled toggle explains why it reverted on failure, next to the toggle.
- **FE-M6** — live task log no longer duplicates lines under overlapping polls (in-flight guard + idempotent append; unit-tested).
- **FE-M8** — the guest list keeps last-known data (with an error note) on a transient error instead of blanking. Backup selection is unaffected — resolved live at run time.

## Settings
- **FE-M2** — unsaved-changes confirmation guard across the config tabs + scheduler, plus a beforeunload guard.
- **FE-M7** — Localization no longer shows "Saved" before saving; fields resync when config changes.
- **FE-M10** — corrected the contradictory Integrations regenerate-key copy; the screen now reads/refreshes via ConfigContext.

## App-wide
- **FE-M1** — client-side request-timeout backstop (45s) so the UI shows a clear error instead of hanging when the backend is unresponsive.

FE-M3 (routing) and BE-S1 (PVE TLS pinning) were reviewed and deliberately skipped for this batch; BE-C5 (auto_include_new dead field) was logged as a new finding.

Verification: frontend tsc + 28 tests + build, i18n parity 314/314; backend 331 passed / 1 skipped, ruff clean. Key flows driven end-to-end against the dev stub.