### PR TITLE
Richer notification bodies, run id in history (0.8.0)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Joulenap version
       description: Shown in the UI footer.
-      placeholder: "0.7.0"
+      placeholder: "0.8.0"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.0]
+
+### Added
+
+- **Notifications say a lot more.** Every run notification now opens with what started the run
+  (scheduled or manual), breaks the duration down by phase (`12m 34s (backup 7m 10s · GC 1m 6s)`),
+  reports guests as a fraction with the names of the ones that failed
+  (`Guests: 12/14 (failed: web01, db02)`), and closes with the next scheduled run and the run
+  number. The alert for a run a restart interrupted also states how long the PBS has been awake.
+  All of it is translated in both languages.
+- **Run history shows the run number.** A new first column, so the `Run #128` a notification
+  quotes can actually be looked up in the interface.
+- **A failed backup names the guest that broke.** Proxmox runs one vzdump task for all selected
+  guests, so a single guest failing used to fail the run with no indication of which one; the
+  outcome is now read off the task log as it streams, so the notification can name it.
+
+### Fixed
+
+- **Notification bodies keep their line breaks.** Channels that deliver in HTML (email, Telegram)
+  collapsed the whole body onto a single line because Apprise was never told the text was plain
+  text.
+- **Notification timestamps all use the configured timezone.** In the missed-backup alert the
+  "Last backup run" line was rendered in UTC while the two lines around it used `app.timezone`,
+  so the same message could disagree with itself by hours.
+
 ## [0.7.0]
 
 ### Added
@@ -327,7 +352,8 @@ Backup Server, all from a web UI.
 - Config-driven via `config.yaml` (pydantic-validated); secrets stay in `config.yaml` and are
   redacted from API responses.
 
-[Unreleased]: https://github.com/Joulenap/joulenap/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/Joulenap/joulenap/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/Joulenap/joulenap/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Joulenap/joulenap/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Joulenap/joulenap/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Joulenap/joulenap/compare/v0.4.4...v0.5.0

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Joulenap **owns the schedule** itself (internal scheduler), so nothing on the Pr
 
 ## Status
 
-**v0.7.0.** Feature-complete: scheduler + Wake-on-LAN + vzdump + retention + GC + verify +
+**v0.8.0.** Feature-complete: scheduler + Wake-on-LAN + vzdump + retention + GC + verify +
 notifications + setup wizard, packaged as a Docker image — with transport hardening (PBS TLS
 pinning + SSH host-key verification) and auth hardening (login rate-limit, session hardening).
 Includes run history with per-step detail, the ability to stop a job mid-run,

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 """Joulenap — web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/backend/app/jobs/backup_cycle.py
+++ b/backend/app/jobs/backup_cycle.py
@@ -10,16 +10,19 @@ power-off step simply never runs.
 
 from __future__ import annotations
 
+import re
+from collections.abc import Callable
 from typing import Any, Protocol
 
 from ..config import Config
 from ..connectors.errors import TaskCancelled
 from ..connectors.pbs import DatastoreStatus
-from ..connectors.pve import PveClient, build_prune_string
+from ..connectors.pve import Guest, build_prune_string
 from ..db import session_scope
 from ..db.datastore_stats import upsert_datastore_stat
 from ..db.guest_backups import upsert_last_backups
 from ..db.models import LogLevel, RunStatus, StepName, StepStatus
+from ..notify.messages import GuestSummary
 from .deps import CycleDeps
 from .recorder import RunRecorder
 
@@ -28,11 +31,39 @@ from .recorder import RunRecorder
 _TAIL_INTERVAL = 2.0
 
 
-def _tailer(recorder: RunRecorder, step: StepName, source: str):
+# vzdump narrates one line per guest; these are its two outcomes:
+#   INFO: Finished Backup of VM 100 (00:01:23)
+#   ERROR: Backup of VM 101 failed - command 'lxc-freeze -n 101' failed: exit code 1
+_VZDUMP_DONE = re.compile(r"Finished Backup of VM (\d+)")
+_VZDUMP_FAILED = re.compile(r"ERROR: Backup of VM (\d+) failed")
+
+
+def _guest_watcher(summary: GuestSummary, names: dict[int, str]):
+    """A log-batch callback that fills ``summary`` from the vzdump output *as it streams*.
+
+    One vzdump task covers every selected guest, so a single guest failing makes the whole
+    task exit non-OK and the wait raises before the step body can record anything. Reading
+    the outcome line by line into an object owned by the *caller* is what makes the tally
+    survive that raise — which is precisely the run the user needs the detail for.
+    """
+
+    def watch(lines: list[tuple[int, str]]) -> None:
+        for _line_no, text in lines:
+            if _VZDUMP_DONE.search(text):
+                summary.ok += 1
+            elif match := _VZDUMP_FAILED.search(text):
+                vmid = int(match.group(1))
+                summary.failed.append(names.get(vmid) or str(vmid))
+
+    return watch
+
+
+def _tailer(recorder: RunRecorder, step: StepName, source: str, watch=None):
     """A ``wait_task(on_log=...)`` callback that persists each task-log batch.
 
     Best-effort: a failure to store a log line must never fail an otherwise-fine backup,
-    so it's swallowed with a warning (the narration just misses a line).
+    so it's swallowed with a warning (the narration just misses a line). ``watch``, when
+    given, also gets each batch — see :func:`_guest_watcher`.
     """
 
     def on_log(lines: list[tuple[int, str]]) -> None:
@@ -40,6 +71,8 @@ def _tailer(recorder: RunRecorder, step: StepName, source: str):
             recorder.task_log(step, source, lines)
         except Exception as exc:  # pragma: no cover - defensive
             recorder.log(LogLevel.WARN, f"could not store task-log line(s): {exc}")
+        if watch is not None:
+            watch(lines)
 
     return on_log
 
@@ -70,6 +103,7 @@ def _wait_or_stop(
     deps: CycleDeps,
     step: StepName,
     source: str,
+    watch: Callable[[list[tuple[int, str]]], None] | None = None,
 ) -> None:
     """Wait for a PVE/PBS task, stopping it remotely if the user cancels the run.
 
@@ -82,7 +116,7 @@ def _wait_or_stop(
         client.wait_task(
             upid,
             poll_interval=_TAIL_INTERVAL,
-            on_log=_tailer(recorder, step, source),
+            on_log=_tailer(recorder, step, source, watch),
             should_cancel=deps.cancelled,
         )
     except TaskCancelled as exc:
@@ -98,30 +132,34 @@ def _wait_or_stop(
         raise CycleCancelled("Run cancelled") from exc
 
 
-def select_vmids(config: Config, pve: PveClient) -> tuple[list[int] | None, bool]:
+def select_vmids(config: Config, guests: list[Guest]) -> tuple[list[int] | None, bool]:
     """Resolve the configured guest selection into vzdump arguments.
 
     Returns ``(vmids, all_guests)``: for ``mode=all`` -> ``(None, True)``; otherwise an
-    explicit id list. ``exclude`` is materialised by listing the node's guests and
-    dropping the excluded ids.
+    explicit id list. ``exclude`` is materialised from ``guests`` (the node's current
+    guests) by dropping the excluded ids.
     """
-    guests = config.backup.guests
-    if guests.mode == "all":
+    selection = config.backup.guests
+    if selection.mode == "all":
         return None, True
-    if guests.mode == "include":
-        return list(guests.list), False
-    excluded = set(guests.list)
-    vmids = [g.vmid for g in pve.list_guests() if g.vmid not in excluded]
-    return vmids, False
+    if selection.mode == "include":
+        return list(selection.list), False
+    excluded = set(selection.list)
+    return [g.vmid for g in guests if g.vmid not in excluded], False
 
 
-def _run_backup_step(config: Config, recorder: RunRecorder, deps: CycleDeps) -> None:
+def _run_backup_step(
+    config: Config, recorder: RunRecorder, deps: CycleDeps, summary: GuestSummary
+) -> None:
     with recorder.step(StepName.BACKUP) as step:
         with deps.build_pve(config) as pve:
-            vmids, all_guests = select_vmids(config, pve)
+            # One listing feeds all three needs: the exclude-mode selection, the guest count
+            # and the {vmid: name} map the notification names failed guests with.
+            guests = pve.list_guests()
+            vmids, all_guests = select_vmids(config, guests)
             if not all_guests and not vmids:
                 raise CycleAbort("No guests selected for backup")
-            guest_count = len(pve.list_guests()) if all_guests else len(vmids)
+            summary.total = len(guests) if all_guests else len(vmids)
             prune = build_prune_string(config.backup.retention.model_dump())
             upid = pve.vzdump(
                 config.pve.storage_id,
@@ -132,10 +170,20 @@ def _run_backup_step(config: Config, recorder: RunRecorder, deps: CycleDeps) -> 
                 bwlimit=config.backup.bwlimit,
             )
             step.detail = upid
-            _wait_or_stop(pve, upid, recorder, deps, StepName.BACKUP, "pve")
-            # Record the count only once the task succeeded, so a failed run doesn't
-            # advertise guests as backed up.
-            recorder.run.guests_ok = guest_count
+            _wait_or_stop(
+                pve,
+                upid,
+                recorder,
+                deps,
+                StepName.BACKUP,
+                "pve",
+                _guest_watcher(summary, {g.vmid: g.name for g in guests}),
+            )
+            # The task exited OK, so every selected guest was backed up whatever the log
+            # parse made of it — a vzdump wording change must never report "0/14" on a good
+            # run. Recorded only here so a failed run doesn't advertise guests as backed up.
+            summary.ok = summary.total
+            recorder.run.guests_ok = summary.total
 
 
 def _preflight_step(config: Config, recorder: RunRecorder, deps: CycleDeps) -> None:
@@ -339,6 +387,9 @@ def run_backup_cycle(
     ``power_off=False`` (manual "keep PBS on") runs everything but the final power-off, so a
     PBS the user wants to keep awake (e.g. woken for a restore) is left on."""
     datastore: DatastoreStatus | None = None
+    # Owned here, not by the backup step: a guest failing takes the whole vzdump task down
+    # and unwinds that frame, and the failed run is exactly the one whose tally we want.
+    guests = GuestSummary()
     try:
         with recorder.step(StepName.WAKE):
             deps.send_wol(config)
@@ -352,7 +403,7 @@ def run_backup_cycle(
                 )
 
         _preflight_step(config, recorder, deps)
-        _run_backup_step(config, recorder, deps)
+        _run_backup_step(config, recorder, deps, guests)
 
         # A cancel that lands between steps must not start the next one — the task waits
         # check the flag themselves, this covers the gaps between them.
@@ -390,7 +441,7 @@ def run_backup_cycle(
     except Exception as exc:  # connector/task failures: leave PBS on, mark failed
         recorder.finish(RunStatus.FAILURE, error=str(exc))
 
-    _notify_result(config, recorder, deps, datastore)
+    _notify_result(config, recorder, deps, datastore, guests)
 
 
 def run_verify_cycle(
@@ -477,10 +528,11 @@ def _notify_result(
     recorder: RunRecorder,
     deps: CycleDeps,
     datastore: DatastoreStatus | None = None,
+    guests: GuestSummary | None = None,
 ) -> None:
     """Send the result notification. A delivery failure is logged, never fatal — the run
     has already completed and its recorded status must not depend on the notifier."""
     try:
-        deps.notify(config, recorder.run, datastore)
+        deps.notify(config, recorder.run, datastore, guests, deps.next_run())
     except Exception as exc:
         recorder.log(LogLevel.WARN, f"notification failed: {exc}")

--- a/backend/app/jobs/deps.py
+++ b/backend/app/jobs/deps.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import ssl
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 
 from ..config import Config
 from ..connectors import net, tls
@@ -19,6 +20,7 @@ from ..connectors.pve import PveClient
 from ..connectors.wol import send_magic_packet
 from ..db.models import Run
 from ..notify import NotificationService
+from ..notify.messages import GuestSummary
 
 
 def _build_pve(config: Config) -> PveClient:
@@ -79,8 +81,14 @@ def _wait_pbs_idle(config: Config) -> bool:
         return pbs.wait_until_idle(timeout=config.pbs.poweroff_task_wait)
 
 
-def _notify(config: Config, run: Run, datastore: DatastoreStatus | None = None) -> None:
-    NotificationService().send_run_result(config, run, datastore)
+def _notify(
+    config: Config,
+    run: Run,
+    datastore: DatastoreStatus | None = None,
+    guests: GuestSummary | None = None,
+    next_at: datetime | None = None,
+) -> None:
+    NotificationService().send_run_result(config, run, datastore, guests, next_at)
 
 
 @dataclass
@@ -93,7 +101,9 @@ class CycleDeps:
     send_wol: Callable[[Config], None]
     wait_reachable: Callable[..., bool]
     wait_pbs_idle: Callable[[Config], bool]
-    notify: Callable[[Config, Run, DatastoreStatus | None], None]
+    # (config, run, datastore, guests, next_at) -> None. Untyped args because the test fakes
+    # take fewer of them; the production implementation is ``_notify`` above.
+    notify: Callable[..., None]
     # True once the user has asked to stop the in-flight run. Wired by JobService to its own
     # cancel event and read live, so the cycle can check it without knowing about the service.
     # Default: nothing ever cancels (tests and direct callers that don't care).
@@ -101,6 +111,10 @@ class CycleDeps:
     # Whether that cancel asked for the PBS to be powered off afterwards (the toggle in the
     # stop dialog). Only meaningful once ``cancelled()`` is True.
     cancel_power_off: Callable[[], bool] = lambda: False
+    # Next armed backup fire, for the notification's "next scheduled run" line. Late-bound by
+    # main.py the same way: the Scheduler lives on app.state and isn't reachable from inside a
+    # running cycle. Default "unknown" — tests and direct callers just omit the line.
+    next_run: Callable[[], datetime | None] = lambda: None
 
     @classmethod
     def default(cls) -> CycleDeps:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -71,6 +71,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     scheduler.start()
     scheduler.rearm(store.config)
     scheduler.arm_prune()
+    # Late-bound so a cycle can put the next scheduled run in its notification: the cycle
+    # only ever sees its CycleDeps, and the Scheduler doesn't exist yet when JobService
+    # builds them (same reason cancelled/cancel_power_off are wired this way).
+    service.deps.next_run = lambda: scheduler.next_run_time
     app.state.job_service = service
     app.state.scheduler = scheduler
     app.state.notifier = NotificationService()

--- a/backend/app/notify/messages.py
+++ b/backend/app/notify/messages.py
@@ -8,7 +8,8 @@ the UI locales but kept deliberately tiny (only the strings that ship in a notif
 
 from __future__ import annotations
 
-from datetime import datetime
+from dataclasses import dataclass, field
+from datetime import datetime, tzinfo
 from typing import TYPE_CHECKING
 
 from ..config import Config
@@ -16,6 +17,25 @@ from ..db.models import Run, RunStatus, StepName, StepStatus
 
 if TYPE_CHECKING:
     from ..connectors.pbs import DatastoreStatus
+
+
+@dataclass
+class GuestSummary:
+    """What the vzdump task did per guest, for the notification's ``Guests`` line.
+
+    Deliberately **not** persisted: ``runs`` has no migration path (``init_db`` only calls
+    ``create_all``, which never adds a column to an existing table), so this rides along to
+    the notifier as an argument exactly like :class:`DatastoreStatus` does.
+
+    ``failed`` holds display names (the vmid when the guest's name is unknown). Only guests
+    vzdump actually reported on can land here, so a guest the user excluded from the
+    selection is never counted or named.
+    """
+
+    total: int = 0  # guests the run set out to back up
+    ok: int = 0
+    failed: list[str] = field(default_factory=list)
+
 
 # event keys: success | failure | aborted | test
 _MESSAGES: dict[str, dict[str, dict[str, str]]] = {
@@ -50,16 +70,28 @@ _MESSAGES: dict[str, dict[str, dict[str, str]]] = {
             "body": "If you can read this, notifications are configured correctly.",
         },
         "_labels": {
+            "trigger": "Trigger",
+            "trigger_scheduled": "scheduled",
+            "trigger_manual": "manual",
             "duration": "Duration",
             "guests": "Guests",
+            "failed": "failed",
             "datastore": "Datastore",
             "used": "used",
             "free": "free",
             "error": "Error",
             "pbs_left_on": "⚠️ PBS left powered on — check it",
+            "awake_for": "PBS awake for",
             "missed_run": "Missed run",
             "last_run": "Last backup run",
             "next_run": "Next scheduled run",
+            "run_no": "Run",
+            # Names for the duration breakdown. Only the phases that do the actual work: the
+            # wake packet is instant, and wait/power-off are near-constant overhead that would
+            # just crowd the line.
+            "phase_backup": "backup",
+            "phase_gc": "GC",
+            "phase_verify": "verify",
         },
     },
     "it": {
@@ -91,16 +123,25 @@ _MESSAGES: dict[str, dict[str, dict[str, str]]] = {
             "body": "Se leggi questo messaggio, le notifiche sono configurate correttamente.",
         },
         "_labels": {
+            "trigger": "Avvio",
+            "trigger_scheduled": "pianificato",
+            "trigger_manual": "manuale",
             "duration": "Durata",
             "guests": "Guest",
+            "failed": "falliti",
             "datastore": "Datastore",
             "used": "usato",
             "free": "liberi",
             "error": "Errore",
             "pbs_left_on": "⚠️ PBS lasciato acceso — controllalo",
+            "awake_for": "PBS sveglio da",
             "missed_run": "Esecuzione mancata",
             "last_run": "Ultimo backup eseguito",
             "next_run": "Prossima esecuzione pianificata",
+            "run_no": "Run",
+            "phase_backup": "backup",
+            "phase_gc": "GC",
+            "phase_verify": "verifica",
         },
     },
 }
@@ -138,6 +179,32 @@ def _format_duration(seconds: float) -> str:
     return f"{secs}s"
 
 
+#: Steps that get a slot in the duration breakdown, keyed to their ``_labels`` entry. Wake,
+#: wait, precheck and power-off are left out on purpose — see the label block's comment.
+_PHASE_LABEL = {
+    StepName.BACKUP: "phase_backup",
+    StepName.GC: "phase_gc",
+    StepName.VERIFY: "phase_verify",
+}
+
+
+def _phase_breakdown(labels: dict[str, str], run: Run) -> str:
+    """``backup 7m 10s · GC 1m 6s`` — where the run's time actually went, in step order.
+
+    Skipped steps (GC turned off) and steps still running contribute nothing, so the
+    parentheses never advertise work that didn't happen. A ``StepName`` added later simply
+    doesn't appear rather than raising.
+    """
+    parts = []
+    for step in run.steps:  # the relationship is ordered by started_at
+        key = _PHASE_LABEL.get(step.name)
+        if key is None or step.status == StepStatus.SKIPPED or not step.finished_at:
+            continue
+        seconds = (step.finished_at - step.started_at).total_seconds()
+        parts.append(f"{labels[key]} {_format_duration(seconds)}")
+    return " · ".join(parts)
+
+
 def human_bytes(n: int) -> str:
     """Binary-unit size, e.g. ``4.6 TiB`` (PBS reports datastore sizes in bytes)."""
     size = float(n)
@@ -170,11 +237,18 @@ def _pbs_left_on(run: Run) -> bool:
 
 
 def build_run_message(
-    config: Config, run: Run, datastore: DatastoreStatus | None = None
+    config: Config,
+    run: Run,
+    datastore: DatastoreStatus | None = None,
+    guests: GuestSummary | None = None,
+    next_at: datetime | None = None,
 ) -> tuple[str, str]:
     """``(title, body)`` describing a finished run, in the configured language.
 
-    ``datastore`` (read while the PBS was still awake) adds a usage line on success.
+    One field per line, in a fixed order; a field whose data is missing drops out entirely
+    rather than rendering a placeholder. ``datastore`` (read while the PBS was still awake)
+    adds the usage line, ``guests`` the per-guest tally of a backup cycle, ``next_at`` the
+    schedule's following fire.
     """
     pack = _pack(config.app.language)
     labels = pack["_labels"]
@@ -182,12 +256,21 @@ def build_run_message(
 
     # The title already conveys success/failure/aborted, so we don't repeat the (untranslated)
     # status enum in the body.
-    lines: list[str] = []
+    lines: list[str] = [
+        f"{labels['trigger']}: {labels.get(f'trigger_{run.trigger}', run.trigger)}"
+    ]
     if run.started_at and run.finished_at:
         duration = (run.finished_at - run.started_at).total_seconds()
-        lines.append(f"{labels['duration']}: {_format_duration(duration)}")
-    if run.guests_ok is not None:
-        lines.append(f"{labels['guests']}: {run.guests_ok}")
+        breakdown = _phase_breakdown(labels, run)
+        line = f"{labels['duration']}: {_format_duration(duration)}"
+        lines.append(f"{line} ({breakdown})" if breakdown else line)
+    # No summary at all (a GC or verify cycle, or an abort before the guests were picked)
+    # means there is nothing truthful to say about guests — better silent than "0".
+    if guests is not None and guests.total:
+        line = f"{labels['guests']}: {guests.ok}/{guests.total}"
+        if guests.failed:
+            line += f" ({labels['failed']}: {', '.join(guests.failed)})"
+        lines.append(line)
     if datastore is not None:
         lines.append(
             f"{labels['datastore']}: {datastore.used_pct}% {labels['used']}, "
@@ -199,17 +282,34 @@ def build_run_message(
     if _pbs_left_on(run):
         lines.append(labels["pbs_left_on"])
 
+    if next_at is not None:
+        lines.append(f"{labels['next_run']}: {_format_dt(next_at, _timezone(config))}")
+    if run.id is not None:
+        lines.append(f"{labels['run_no']} #{run.id}")
+
     return _title_for(pack, run.kind, event), "\n".join(lines)
 
 
-def _format_dt(dt: datetime | None) -> str:
+def _timezone(config: Config) -> tzinfo:
+    """The zone every timestamp in a notification is rendered in.
+
+    Imported here rather than at module scope because ``core.scheduler`` pulls in ``jobs``,
+    which pulls in this package — a top-level import would be circular."""
+    from ..core.scheduler import resolve_timezone
+
+    return resolve_timezone(config.app.timezone)
+
+
+def _format_dt(dt: datetime | None, tz: tzinfo) -> str:
     """A short absolute timestamp for notifications, e.g. ``2026-07-11 04:00 CEST``.
 
-    The datetimes passed here come straight from the schedule's cron trigger, so they are
-    already in the user's configured timezone — no re-localisation needed."""
+    Everything is converted into the configured zone first. Cron-derived times already
+    arrive in it, but anything read back from the database is UTC (see ``UtcDateTime``) —
+    without the conversion one line of the same message would silently be hours off from
+    the ones around it."""
     if dt is None:
         return "—"
-    return dt.strftime("%Y-%m-%d %H:%M %Z").rstrip()
+    return dt.astimezone(tz).strftime("%Y-%m-%d %H:%M %Z").rstrip()
 
 
 def build_missed_backup_message(
@@ -219,12 +319,13 @@ def build_missed_backup_message(
     over its window (BE-R1), in the configured language."""
     pack = _pack(config.app.language)
     labels = pack["_labels"]
+    tz = _timezone(config)
     lines = [
         pack["missed"]["intro"],
         "",
-        f"{labels['missed_run']}: {_format_dt(missed_at)}",
-        f"{labels['last_run']}: {_format_dt(last_run_at)}",
-        f"{labels['next_run']}: {_format_dt(next_at)}",
+        f"{labels['missed_run']}: {_format_dt(missed_at, tz)}",
+        f"{labels['last_run']}: {_format_dt(last_run_at, tz)}",
+        f"{labels['next_run']}: {_format_dt(next_at, tz)}",
     ]
     return pack["missed"]["title"], "\n".join(lines)
 
@@ -237,12 +338,31 @@ def build_interrupted_message(config: Config, run: Run) -> tuple[str, str]:
     (WAIT succeeded, no POWEROFF) — the whole point of the alert: a normally-off box that a
     crash left awake and burning power."""
     pack = _pack(config.app.language)
+    labels = pack["_labels"]
     lines = [pack["interrupted"]["intro"]]
     if run.error:
-        lines.append(f"{pack['_labels']['error']}: {run.error}")
+        lines.append(f"{labels['error']}: {run.error}")
     if _pbs_left_on(run):
-        lines.append(pack["_labels"]["pbs_left_on"])
+        lines.append(labels["pbs_left_on"])
+        # This alert has no Duration line (the run's own span would span the whole downtime,
+        # not the work), so the one interval worth reporting is how long the box has been
+        # awake: from the moment it came up to the restart — and, since nothing powered it
+        # off, counting still.
+        awake_since = _awake_since(run)
+        if awake_since and run.finished_at:
+            awake = (run.finished_at - awake_since).total_seconds()
+            lines.append(f"{labels['awake_for']}: {_format_duration(awake)}")
+    if run.id is not None:
+        lines.append(f"{labels['run_no']} #{run.id}")
     return pack["interrupted"]["title"], "\n".join(lines)
+
+
+def _awake_since(run: Run) -> datetime | None:
+    """When the PBS finished coming up — the WAIT step's finish, or None if it never did."""
+    for step in run.steps:
+        if step.name == StepName.WAIT and step.status == StepStatus.SUCCESS:
+            return step.finished_at
+    return None
 
 
 def build_test_message(config: Config) -> tuple[str, str]:

--- a/backend/app/notify/service.py
+++ b/backend/app/notify/service.py
@@ -24,7 +24,12 @@ import apprise
 from ..config import Config, NotificationsConfig
 from ..db.models import Run, RunStatus
 from .apprise_urls import Channel, build_channels
-from .messages import build_missed_backup_message, build_run_message, build_test_message
+from .messages import (
+    GuestSummary,
+    build_missed_backup_message,
+    build_run_message,
+    build_test_message,
+)
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -134,7 +139,12 @@ class NotificationService:
         self._apprise_factory = apprise_factory
 
     def send_run_result(
-        self, config: Config, run: Run, datastore: DatastoreStatus | None = None
+        self,
+        config: Config,
+        run: Run,
+        datastore: DatastoreStatus | None = None,
+        guests: GuestSummary | None = None,
+        next_at: datetime | None = None,
     ) -> NotifyReport:
         """Notify the run outcome, honouring the on_success / on_failure routing toggles."""
         n = config.notifications
@@ -142,7 +152,7 @@ class NotificationService:
             return NotifyReport(sent=False, channels=0, skipped=True, reason="on_success disabled")
         if run.status in (RunStatus.FAILURE, RunStatus.ABORTED) and not n.on_failure:
             return NotifyReport(sent=False, channels=0, skipped=True, reason="on_failure disabled")
-        title, body = build_run_message(config, run, datastore)
+        title, body = build_run_message(config, run, datastore, guests, next_at)
         report = self._dispatch(build_channels(n), title, body, n)
         # A run notification has no UI: without this, a channel that silently stopped working
         # would never surface anywhere.
@@ -220,7 +230,13 @@ class NotificationService:
             if not engine.add(channel.url):
                 return ChannelResult(channel=channel.name, ok=False, error="invalid URL")
             with _captured_apprise_logs() as captured:
-                ok = bool(engine.notify(title=title, body=body))
+                # Declare the body as plain text. Without this Apprise leaves it unconverted,
+                # so an HTML-format channel (email, Telegram) renders our "\n" separators as
+                # spaces and the whole body collapses onto one line. With it, Apprise turns
+                # them into <br/> for HTML channels and leaves text/markdown ones untouched.
+                ok = bool(
+                    engine.notify(title=title, body=body, body_format=apprise.NotifyFormat.TEXT)
+                )
         except Exception as exc:  # a broken channel must not stop the others
             return ChannelResult(
                 channel=channel.name, ok=False, error=_scrub(str(exc), channel_secrets)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "joulenap"
-version = "0.7.0"
+version = "0.8.0"
 description = "Self-hosted web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."
 readme = "../README.md"
 requires-python = ">=3.12"

--- a/backend/tests/fakes.py
+++ b/backend/tests/fakes.py
@@ -194,6 +194,6 @@ def make_deps(
         # Second arg is the cancel probe the real _wait_reachable takes; fakes ignore it.
         wait_reachable=lambda _c, _cancel=None: wait(),
         wait_pbs_idle=lambda _c: idle(),
-        notify=notify or (lambda _c, _r, _d=None: None),
+        notify=notify or (lambda *_a: None),
     )
     return deps, pve, pbs, power

--- a/backend/tests/test_backup_cycle.py
+++ b/backend/tests/test_backup_cycle.py
@@ -452,6 +452,75 @@ def test_backup_records_guest_count(temp_db):
         assert session.get(Run, run_id).guests_ok == 2
 
 
+def _guests() -> list[Guest]:
+    return [
+        Guest(vmid=100, name="web01", type="lxc", status="running"),
+        Guest(vmid=101, name="db02", type="qemu", status="running"),
+    ]
+
+
+def _notified_guests(cfg: Config, pve: FakePve):
+    """Run a cycle and hand back the GuestSummary the notification was built from."""
+    captured = {}
+    deps, _pve, _pbs, _power = make_deps(
+        pve=pve, notify=lambda _c, _r, _d, guests, _n: captured.update(summary=guests)
+    )
+    _run(cfg, deps)
+    return captured["summary"]
+
+
+def test_failed_backup_names_the_guests_that_failed(temp_db):
+    """One vzdump task covers every guest, so a single guest failing takes the whole task
+    down and unwinds the step before it can record anything — the tally has to be filled from
+    the log as it streams, into an object the step doesn't own."""
+    pve = FakePve(
+        guests=_guests(),
+        fail_task=True,
+        log_lines=[
+            "INFO: Starting Backup of VM 100 (lxc)",
+            "INFO: Finished Backup of VM 100 (00:00:12)",
+            "INFO: Starting Backup of VM 101 (qemu)",
+            "ERROR: Backup of VM 101 failed - command 'qm' failed: exit code 1",
+        ],
+    )
+    summary = _notified_guests(_config(), pve)
+
+    assert (summary.total, summary.ok, summary.failed) == (2, 1, ["db02"])
+
+
+def test_successful_backup_reports_every_guest_ok(temp_db):
+    # No parseable per-guest lines at all: a vzdump wording change must never make a good run
+    # advertise "0/2".
+    summary = _notified_guests(_config(), FakePve(guests=_guests()))
+
+    assert (summary.total, summary.ok, summary.failed) == (2, 2, [])
+
+
+def test_excluded_guests_are_never_counted_as_failed(temp_db):
+    # The excluded guest is not in the vzdump log at all, so it can't land in either bucket —
+    # the total is the kept guests only.
+    summary = _notified_guests(
+        _config(guests_mode="exclude", guests_list=[101]), FakePve(guests=_guests())
+    )
+
+    assert (summary.total, summary.failed) == (1, [])
+
+
+def test_next_run_time_reaches_the_notification(temp_db):
+    from datetime import UTC, datetime
+
+    captured = {}
+    deps, _pve, _pbs, _power = make_deps(
+        notify=lambda _c, _r, _d, _g, next_at: captured.update(next_at=next_at)
+    )
+    when = datetime(2026, 6, 29, 4, 0, tzinfo=UTC)
+    deps.next_run = lambda: when
+
+    _run(_config(), deps)
+
+    assert captured["next_at"] == when
+
+
 def test_exclude_mode_filters_listed_vmids(temp_db):
     guests = [
         Guest(vmid=100, name="a", type="lxc", status="running"),
@@ -504,7 +573,7 @@ def test_datastore_read_failure_is_best_effort(temp_db):
     cfg = _config()
     captured = {}
 
-    def capture(config, run, ds=None):
+    def capture(config, run, ds=None, *_a):
         captured["status"] = run.status
         captured["ds"] = ds
 
@@ -528,7 +597,7 @@ def test_failed_cycle_notifies_with_failure_content(temp_db):
     cfg = _config()
     captured = {}
 
-    def capture(config, run, ds=None):
+    def capture(config, run, ds=None, *_a):
         captured["run"] = run
         captured["title"], captured["body"] = build_run_message(config, run, ds)
 
@@ -593,7 +662,7 @@ def test_cancel_before_the_pbs_wakes_does_not_try_to_power_off(temp_config, temp
 def test_cancel_does_not_notify(temp_config, temp_db):
     # The user pressed Stop and is standing at the UI; a "backup aborted" push is noise.
     sent = []
-    deps, _pve, _pbs, _power = _cancelled_deps(notify=lambda c, r, d=None: sent.append(r))
+    deps, _pve, _pbs, _power = _cancelled_deps(notify=lambda c, r, *_a: sent.append(r))
     _run(_config(), deps)
     assert sent == []
 

--- a/backend/tests/test_notify.py
+++ b/backend/tests/test_notify.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from fakes import make_deps
 from fastapi.testclient import TestClient
@@ -17,6 +17,7 @@ from app.main import create_app
 from app.notify import NotificationService
 from app.notify.apprise_urls import Channel, build_channels
 from app.notify.messages import (
+    GuestSummary,
     build_interrupted_message,
     build_missed_backup_message,
     build_run_message,
@@ -48,6 +49,7 @@ class FakeApprise:
         self.raise_urls = raise_urls or {}
         self.urls: list[str] = []
         self.payload: tuple[str, str] | None = None
+        self.body_format: str | None = None
 
     def add(self, url: str) -> bool:
         if not self.add_ok:
@@ -55,8 +57,9 @@ class FakeApprise:
         self.urls.append(url)
         return True
 
-    def notify(self, title: str = "", body: str = "") -> bool:
+    def notify(self, title: str = "", body: str = "", body_format: str = "") -> bool:
         self.payload = (title, body)
+        self.body_format = body_format
         url = self.urls[-1]
         if url in self.raise_urls:
             raise RuntimeError(self.raise_urls[url])
@@ -163,12 +166,25 @@ def test_ntfy_http_uses_insecure_scheme():
 
 
 def _run(
-    status: RunStatus, *, error: str | None = None, kind: RunKind = RunKind.CYCLE
+    status: RunStatus,
+    *,
+    error: str | None = None,
+    kind: RunKind = RunKind.CYCLE,
+    trigger: RunTrigger = RunTrigger.MANUAL,
 ) -> Run:
-    run = Run(kind=kind, trigger=RunTrigger.MANUAL, status=status, error=error)
+    run = Run(kind=kind, trigger=trigger, status=status, error=error)
+    run.id = 128
     run.started_at = datetime(2026, 6, 28, 4, 0, 0, tzinfo=UTC)
     run.finished_at = datetime(2026, 6, 28, 4, 1, 23, tzinfo=UTC)
     return run
+
+
+def _step(name: StepName, status: StepStatus, seconds: int) -> RunStep:
+    """A finished step that took ``seconds``, for the duration breakdown."""
+    step = RunStep(name=name, status=status)
+    step.started_at = datetime(2026, 6, 28, 4, 0, 0, tzinfo=UTC)
+    step.finished_at = step.started_at + timedelta(seconds=seconds)
+    return step
 
 
 def test_run_message_success_english():
@@ -181,19 +197,99 @@ def test_run_message_includes_guests_and_datastore():
     from app.connectors.pbs import DatastoreStatus
 
     run = _run(RunStatus.SUCCESS)
-    run.guests_ok = 4
     ds = DatastoreStatus(total=8_000_000_000_000, used=2_000_000_000_000, avail=6_000_000_000_000)
-    _title, body = build_run_message(Config(), run, ds)
-    assert "Guests: 4" in body
+    _title, body = build_run_message(Config(), run, ds, GuestSummary(total=4, ok=4))
+    assert "Guests: 4/4" in body
     assert "25.0% used" in body
     assert "5.5 TiB free" in body
 
 
 def test_run_message_omits_guests_and_datastore_when_absent():
-    # No guests_ok and no datastore -> neither line appears (e.g. an aborted run).
+    # No guest summary and no datastore -> neither line appears (e.g. an aborted run).
     _title, body = build_run_message(Config(), _run(RunStatus.ABORTED))
     assert "Guests" not in body
     assert "Datastore" not in body
+
+
+def test_run_message_names_the_guests_that_failed():
+    """A single guest failing takes the whole vzdump task down, so the run reads FAILURE with
+    no hint of which guest broke. The tally is the only place that detail exists."""
+    _title, body = build_run_message(
+        Config(),
+        _run(RunStatus.FAILURE, error="vzdump failed"),
+        None,
+        GuestSummary(total=14, ok=12, failed=["web01", "db02"]),
+    )
+    assert "Guests: 12/14 (failed: web01, db02)" in body
+
+
+def test_run_message_omits_the_guest_line_when_nothing_was_selected():
+    # total == 0 means the cycle never got as far as picking guests: "0/0" would read like a
+    # result when it is really an absence.
+    _title, body = build_run_message(Config(), _run(RunStatus.ABORTED), None, GuestSummary())
+    assert "Guests" not in body
+
+
+def test_run_message_field_order():
+    """The order is the spec — asserting the lines individually wouldn't catch a reshuffle."""
+    from app.connectors.pbs import DatastoreStatus
+
+    run = _run(RunStatus.FAILURE, error="boom", trigger=RunTrigger.SCHEDULED)
+    run.steps = [_woke(), RunStep(name=StepName.BACKUP, status=StepStatus.FAILURE)]
+    ds = DatastoreStatus(total=8_000_000_000_000, used=2_000_000_000_000, avail=6_000_000_000_000)
+    _title, body = build_run_message(
+        Config(),
+        run,
+        ds,
+        GuestSummary(total=2, ok=1, failed=["web01"]),
+        datetime(2026, 6, 29, 4, 0, tzinfo=UTC),
+    )
+    assert [line.split(":")[0] for line in body.splitlines()] == [
+        "Trigger",
+        "Duration",
+        "Guests",
+        "Datastore",
+        "Error",
+        "⚠️ PBS left powered on — check it",
+        "Next scheduled run",
+        "Run #128",
+    ]
+
+
+def test_run_message_duration_breaks_down_the_work_phases():
+    """Where the time actually went. Wake/wait/power-off stay out: near-constant overhead
+    that would only crowd the line."""
+    run = _run(RunStatus.SUCCESS)
+    run.steps = [
+        _step(StepName.WAIT, StepStatus.SUCCESS, 40),
+        _step(StepName.BACKUP, StepStatus.SUCCESS, 70),
+        RunStep(name=StepName.GC, status=StepStatus.SKIPPED),
+        _step(StepName.POWEROFF, StepStatus.SUCCESS, 9),
+    ]
+    _title, body = build_run_message(Config(), run)
+    assert "Duration: 1m 23s (backup 1m 10s)" in body
+
+
+def test_run_message_trigger_and_next_run_are_localized():
+    cfg = Config()
+    cfg.app.language = "it"
+    _title, body = build_run_message(
+        cfg,
+        _run(RunStatus.SUCCESS, trigger=RunTrigger.SCHEDULED),
+        None,
+        None,
+        datetime(2026, 6, 29, 4, 0, tzinfo=UTC),
+    )
+    assert body.startswith("Avvio: pianificato")
+    assert "Prossima esecuzione pianificata: 2026-06-29 04:00" in body
+    assert body.endswith("Run #128")
+
+
+def test_run_message_omits_next_run_when_no_schedule_is_armed():
+    # A disabled/invalid schedule leaves no armed job: better no line than a "—" placeholder,
+    # which reads like an error in an otherwise-fine success push.
+    _title, body = build_run_message(Config(), _run(RunStatus.SUCCESS))
+    assert "Next scheduled run" not in body
 
 
 def test_run_message_failure_includes_error_and_locale():
@@ -333,6 +429,32 @@ def test_send_missed_backup_skipped_when_on_failure_disabled():
     assert report.reason == "on_failure disabled"
 
 
+def test_missed_backup_message_renders_every_time_in_the_configured_zone():
+    """The missed/next times come from the cron trigger (already local) but the last run is
+    read back from the database in UTC — so this message used to mix two zones, with one line
+    silently hours off from the two around it."""
+    cfg = Config()
+    cfg.app.timezone = "Europe/Rome"  # UTC+2 in July
+    _title, body = build_missed_backup_message(
+        cfg,
+        datetime(2026, 7, 9, 2, 0, tzinfo=UTC),
+        datetime(2026, 7, 8, 2, 0, tzinfo=UTC),
+        datetime(2026, 7, 10, 2, 0, tzinfo=UTC),
+    )
+    assert "Missed run: 2026-07-09 04:00 CEST" in body
+    assert "Last backup run: 2026-07-08 04:00 CEST" in body
+    assert "Next scheduled run: 2026-07-10 04:00 CEST" in body
+
+
+def test_run_message_next_run_uses_the_configured_zone():
+    cfg = Config()
+    cfg.app.timezone = "Europe/Rome"
+    _title, body = build_run_message(
+        cfg, _run(RunStatus.SUCCESS), None, None, datetime(2026, 7, 10, 2, 0, tzinfo=UTC)
+    )
+    assert "Next scheduled run: 2026-07-10 04:00 CEST" in body
+
+
 def test_interrupted_message_flags_pbs_left_on_when_it_had_woken():
     # Crashed during backup after the PBS woke: WAIT succeeded, no POWEROFF -> warn.
     run = _run(RunStatus.FAILURE, error="Interrupted — Joulenap restarted")
@@ -355,6 +477,28 @@ def test_interrupted_message_no_pbs_line_when_it_never_woke():
     ]
     _title, body = build_interrupted_message(Config(), run)
     assert "left powered on" not in body
+
+
+def test_interrupted_message_reports_how_long_the_pbs_has_been_awake():
+    """This alert has no Duration line, and the interval that matters isn't the run's — it's
+    how long the box has been burning power since it woke, which nothing has switched off."""
+    run = _run(RunStatus.FAILURE, error="Interrupted")
+    run.finished_at = datetime(2026, 6, 28, 13, 12, 0, tzinfo=UTC)  # the restart (sweep) time
+    run.steps = [
+        _step(StepName.WAIT, StepStatus.SUCCESS, 40),  # came up at 04:00:40
+        RunStep(name=StepName.BACKUP, status=StepStatus.FAILURE),
+    ]
+    _title, body = build_interrupted_message(Config(), run)
+    assert "PBS awake for: 9h 11m 20s" in body
+    assert body.endswith("Run #128")
+
+
+def test_interrupted_message_no_awake_line_when_it_never_woke():
+    # WAIT failed: the box never came up, so there is no interval to report (and no warning).
+    run = _run(RunStatus.FAILURE, error="Interrupted")
+    run.steps = [_step(StepName.WAIT, StepStatus.FAILURE, 300)]
+    _title, body = build_interrupted_message(Config(), run)
+    assert "awake for" not in body
 
 
 def test_interrupted_message_localized_italian():
@@ -414,6 +558,22 @@ def test_send_test_dispatches_to_every_channel():
     assert fake.payload is not None
 
 
+def test_body_is_declared_as_plain_text_so_html_channels_keep_the_line_breaks():
+    """Every body is a "Label: value" list separated by newlines. Apprise only converts those
+    newlines for an HTML-format channel (email, Telegram) when told the input is TEXT —
+    without the declaration the whole body renders on a single line."""
+    from apprise.common import NotifyFormat
+    from apprise.conversion import convert_between
+
+    fake = FakeApprise()
+    svc = NotificationService(apprise_factory=lambda: fake)
+    svc.send_test(_notifications_config())
+
+    assert fake.body_format == NotifyFormat.TEXT
+    rendered = convert_between(fake.body_format, NotifyFormat.HTML, "Duration: 8m\nGuests: 13")
+    assert "<br/>" in rendered
+
+
 def test_send_test_with_no_channels_reports_reason():
     svc = NotificationService(apprise_factory=FakeApprise)
     report = svc.send_test(Config())
@@ -466,7 +626,7 @@ def test_a_raising_add_does_not_leak_the_url():
         def add(self, url: str) -> bool:
             raise RuntimeError(f"cannot parse {url}")
 
-        def notify(self, title: str = "", body: str = "") -> bool:
+        def notify(self, title: str = "", body: str = "", body_format: str = "") -> bool:
             raise AssertionError("notify must not run when add raised")
 
     svc = NotificationService(apprise_factory=RaisingAdd)
@@ -565,7 +725,7 @@ def test_log_capture_is_isolated_per_thread():
             self.urls.append(url)
             return True
 
-        def notify(self, title: str = "", body: str = "") -> bool:
+        def notify(self, title: str = "", body: str = "", body_format: str = "") -> bool:
             # Simulate a concurrent send on another thread logging to the same "apprise"
             # logger while this send is in flight. Joined (not slept) so the emission is
             # guaranteed to happen, deterministically, before notify() returns.
@@ -614,7 +774,9 @@ def test_failure_sent_when_on_failure_enabled():
 
 def test_backup_cycle_notifies_with_final_run(temp_db):
     captured: list[tuple[RunStatus, bool]] = []
-    deps, *_ = make_deps(notify=lambda _c, run, ds: captured.append((run.status, ds is not None)))
+    deps, *_ = make_deps(
+        notify=lambda _c, run, ds, *_a: captured.append((run.status, ds is not None))
+    )
     cfg = Config()
     cfg.pve.storage_id = "pbs"
     with RunRecorder(RunKind.CYCLE, RunTrigger.MANUAL) as recorder:
@@ -624,7 +786,7 @@ def test_backup_cycle_notifies_with_final_run(temp_db):
 
 
 def test_notify_failure_does_not_break_cycle(temp_db):
-    def boom(_c, _run, _ds=None):
+    def boom(_c, _run, _ds=None, *_a):
         raise RuntimeError("smtp down")
 
     deps, *_ = make_deps(notify=boom)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joulenap-frontend",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/devStub.ts
+++ b/frontend/src/devStub.ts
@@ -374,10 +374,10 @@ notifications:
 `
 
 const ROUTES: Record<string, unknown> = {
-  'GET /health': { status: 'ok', version: '0.7.0-stub' },
+  'GET /health': { status: 'ok', version: '0.8.0-stub' },
   'GET /update': {
-    current: '0.7.0-stub',
-    latest: '0.7.0',
+    current: '0.8.0-stub',
+    latest: '0.8.0',
     update_available: true,
     url: 'https://github.com/Joulenap/joulenap/releases',
   },

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -116,6 +116,7 @@
     "historyViews": "Activity views",
     "runHistory": "Run history",
     "runsCount": "{{n}} runs",
+    "colId": "Run",
     "colStarted": "Started",
     "colKind": "Job",
     "colTrigger": "Trigger",

--- a/frontend/src/i18n/it.json
+++ b/frontend/src/i18n/it.json
@@ -116,6 +116,7 @@
     "historyViews": "Viste attività",
     "runHistory": "Cronologia",
     "runsCount": "{{n}} esecuzioni",
+    "colId": "Run",
     "colStarted": "Inizio",
     "colKind": "Operazione",
     "colTrigger": "Avvio",

--- a/frontend/src/pages/dashboard/RunHistory.tsx
+++ b/frontend/src/pages/dashboard/RunHistory.tsx
@@ -112,6 +112,7 @@ export function RunHistory({ runs, error }: { runs: RunSummary[]; error: boolean
         className="jn-run-head"
         style={{ padding: '0 18px 7px', borderBottom: `1px solid ${c.border}` }}
       >
+        <span style={colHead}>{t('dashboard.colId')}</span>
         <span style={colHead}>{t('dashboard.colStarted')}</span>
         <span style={colHead}>{t('dashboard.colKind')}</span>
         <span style={colHead}>{t('dashboard.colTrigger')}</span>
@@ -148,6 +149,9 @@ export function RunHistory({ runs, error }: { runs: RunSummary[]; error: boolean
                   color: c.text,
                 }}
               >
+                {/* The run number the notifications quote — this is where you come to look
+                    it up, so it leads the row. */}
+                <span style={{ ...cell, color: c.textMuted }}>#{run.id}</span>
                 <span style={{ ...cell, color: c.textFaint }}>
                   <span style={{ color: c.textFaint, marginRight: 6 }}>{open ? '▾' : '▸'}</span>
                   {fmtShort(new Date(run.started_at))}

--- a/frontend/src/responsive.css
+++ b/frontend/src/responsive.css
@@ -90,11 +90,11 @@
   grid-template-columns: 84px 96px 1fr;
 }
 
-/* Run history: started | kind | trigger | status | duration | guests */
+/* Run history: id | started | kind | trigger | status | duration | guests */
 .jn-run-head,
 .jn-run-row {
   display: grid;
-  grid-template-columns: 116px 90px 92px 92px 72px 1fr;
+  grid-template-columns: 52px 116px 90px 92px 92px 72px 1fr;
   gap: 8px;
 }
 
@@ -197,17 +197,23 @@
     grid-column: 1 / -1;
   }
 
-  /* Same treatment for run rows: drop the six column labels, then two lines per run —
-   * started + kind + status on the first, trigger/duration/guests on the second. */
+  /* Same treatment for run rows: drop the column labels, then two lines per run — id +
+   * started + kind + trigger on the first, status/duration/guests on the second. The
+   * nth-child index is positional, so it moves with the column count. */
   .jn-run-head {
     display: none;
   }
   .jn-run-row {
-    grid-template-columns: 106px 1fr auto;
+    grid-template-columns: 44px 100px 1fr auto;
     row-gap: 3px;
   }
-  .jn-run-row > :nth-child(n + 4) {
+  .jn-run-row > :nth-child(n + 5) {
     grid-row: 2;
+  }
+  /* The result badge opens the second line, where it would otherwise land in the narrow
+   * id track and run into the duration next to it. */
+  .jn-run-row > :nth-child(5) {
+    grid-column: 1 / 3;
   }
 
   .jn-settings {


### PR DESCRIPTION
## What

Run notifications carried three fields and one of them was misleading. This turn they carry
what actually happened, one field per line:

```
Trigger: scheduled
Duration: 3m 7s (backup 2m 20s)
Guests: 12/14 (failed: web01, db02)
Datastore: 28.3% used, 1.6 TiB free
Error: Task UPID:pve:... finished with status 'job errors'
⚠️ PBS left powered on — check it
Next scheduled run: 2026-07-26 04:00 CEST
Run #129
```

The alert for a run a restart interrupted has no duration to report, so it states how long the
PBS has been awake instead. Everything is translated in both languages.

## Naming the guest that failed

`guests_ok` was never a success count: Proxmox runs one vzdump task for every selected guest, so
a single guest failing makes the whole task exit non-OK, the wait raises, and the run is recorded
FAILURE with `guests_ok` left unset. The one run whose detail matters reported nothing.

Per-guest outcomes exist only in the raw vzdump log, which already streams through the tailer. They
are now parsed as the lines arrive, into a summary object owned by the caller rather than the step
frame — which is what makes the tally survive the exception that unwinds it. Guests the user
excluded from the selection never appear in that log, so they can never be counted or named.

Nothing new is persisted: the summary rides along to the notifier as an argument, the way the
datastore reading already does. `runs` has no migration path (`init_db` only calls `create_all`,
which never adds a column to an existing table), so a new column would break every live 0.7.0
database.

## Fixed

- **Bodies were collapsed onto one line** on channels that deliver in HTML (email, Telegram).
  Apprise leaves the body unconverted unless told the input is plain text, so the `\n` separators
  reached the renderer as-is and became spaces.
- **The missed-backup alert mixed two timezones.** "Last backup run" is read from the database in
  UTC while the two lines around it come from the cron trigger in `app.timezone`, so the same
  message could disagree with itself by hours. Fixed in the shared formatter, so every timestamp
  in every notification is converted.

## Run history

The run number the notifications quote is now the first column of the run history table — it was
already served by the API and typed on the client, just never shown. On narrow screens the result
badge opens the second line and would have landed in the new (narrow) id track, so it spans two.

## Testing

405 backend tests, 40 frontend tests, ruff and `tsc --noEmit` clean. The run history was checked
in the browser at 1280px and 390px against the dev stub.
