### PR TITLE
Release 1.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Joulenap version
       description: Shown in the UI footer.
-      placeholder: "1.0.0"
+      placeholder: "1.1.0"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0]
+
 ### Added
 
 - Sync routes can now keep an independent, tighter retention on the target: the route's
@@ -616,7 +618,8 @@ Backup Server, all from a web UI.
 - Config-driven via `config.yaml` (pydantic-validated); secrets stay in `config.yaml` and are
   redacted from API responses.
 
-[Unreleased]: https://github.com/Joulenap/joulenap/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/Joulenap/joulenap/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/Joulenap/joulenap/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Joulenap/joulenap/compare/v0.9.0...v1.0.0
 [0.9.0]: https://github.com/Joulenap/joulenap/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Joulenap/joulenap/compare/v0.7.0...v0.8.0

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Joulenap **owns the schedule** itself (internal scheduler), so nothing on the Pr
 
 ## Status
 
-**v1.0.0.** Built around routes over any number of PVE and PBS devices: backup, PBS→PBS sync,
+**v1.1.0.** Built around routes over any number of PVE and PBS devices: backup, PBS→PBS sync,
 external-schedule watching and verification, driven by a run queue and a per-server power lease
 so a box is woken once and slept once no matter how many routes need it. Packaged as a Docker
 image, with transport hardening (per-device PBS TLS pinning + SSH host-key verification) and auth
@@ -66,7 +66,10 @@ hardening (login rate-limit, session hardening). Includes guided wizards for add
 PBS, run history with a per-step timeline and live task output, the ability to stop a run
 mid-flight, [integrations](docs/INTEGRATIONS.md) for dashboards (Homepage/Homarr/Dashy/Glance)
 and Prometheus, persistent datastore usage shown even while a server is powered off, a
-per-channel notification test report, and a responsive UI that works on a phone.
+per-channel notification test report, and a responsive UI that works on a phone. 1.1 adds
+an independent retention on the target of a sync route (plus PBS `transfer-last` /
+`remove-vanished`), a no-progress timeout on task waits instead of a hard 6-hour cap, and
+runs that can no longer be left hanging by a failed database write.
 See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the design and API.
 
 **Known limitation.** Joulenap reads the **root namespace** of a PBS datastore: if your Proxmox

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 """Joulenap — web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."""
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "joulenap"
-version = "1.0.0"
+version = "1.1.0"
 description = "Self-hosted web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."
 requires-python = ">=3.12"
 license = { text = "AGPL-3.0-or-later" }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joulenap-frontend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joulenap-frontend",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/lang-yaml": "^6.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joulenap-frontend",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/devStub.ts
+++ b/frontend/src/devStub.ts
@@ -822,11 +822,11 @@ function demoRoute(key: string, search: URLSearchParams, init?: RequestInit): un
     // The stub's "-stub" marker and its pending-update badge are dev affordances; a public
     // demo should look like a current, healthy install.
     case 'GET /health':
-      return { status: 'ok', version: '1.0.0' }
+      return { status: 'ok', version: '1.1.0' }
     case 'GET /update':
       return {
-        current: '1.0.0',
-        latest: '1.0.0',
+        current: '1.1.0',
+        latest: '1.1.0',
         update_available: false,
         url: 'https://github.com/Joulenap/joulenap/releases',
       }
@@ -1081,10 +1081,10 @@ const WIZARD_WOL_TEST: { sent: boolean; mac: string; broadcast: string } = {
 }
 
 const ROUTES: Record<string, unknown> = {
-  'GET /health': { status: 'ok', version: '1.0.0-stub' },
+  'GET /health': { status: 'ok', version: '1.1.0-stub' },
   'GET /update': {
-    current: '1.0.0-stub',
-    latest: '1.0.0',
+    current: '1.1.0-stub',
+    latest: '1.1.0',
     update_available: true,
     url: 'https://github.com/Joulenap/joulenap/releases',
   },


### PR DESCRIPTION
Version bump to 1.1.0.

### Added
- Sync routes: the route's retention is now applied on the target datastore after each sync (new `prune` step, before GC), plus `options.transfer_last` (PBS `transfer-last`) and `options.remove_vanished` (PBS `remove-vanished`, opt-in) — an off-site or S3-backed copy can stay smaller than its source (#36).
- PBS token grant for sync routes is `RemoteAdmin` + `RemoteDatastoreAdmin`; re-run **Grant sync permissions** on a 1.0 box before enabling `remove_vanished` on a push route.

### Fixed
- Task waits use a no-progress timeout instead of a hard 6-hour cap; long healthy syncs are no longer reported failed (#37).
- A run can no longer stay "Running" after its worker dies on a failed database write; Stop run closes out an orphaned run instead of 409; PVE's "no content" placeholder is dropped from the task log (#38).

### Changed
- Sync routes configured before 1.1.0 carry the form's default retention (7/4/6) which was inert; it now prunes the target on the next run — review it, or set every keep-* to 0.
