### PR TITLE
Release 1.1.1: report a run that cannot start; SQLite synchronous=NORMAL, 30 s busy timeout

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Joulenap version
       description: Shown in the UI footer.
-      placeholder: "1.1.0"
+      placeholder: "1.1.1"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.1]
+
+### Fixed
+
+- A run that could not create its own history row (SQLite `database is locked` past the busy
+  timeout, a full disk) used to vanish: no row, no notification, one line in the container
+  log, so a scheduled sync looked as if it had never fired. It is now reported on the
+  configured notification channels as a failed run (without a run number) and the single-run
+  lock is released as usual (#38).
+- The SQLite database now uses `synchronous=NORMAL` with WAL, so a commit no longer fsyncs on
+  every task-log line, and the busy timeout is 30 s instead of 5 s. A disk that stalls for a
+  few seconds under a running backup (a VM on spinning disks, for instance) no longer turns
+  a task-log write into `database is locked` and a failed run. In WAL this remains safe across
+  an application crash; a power loss can at worst lose the last few seconds of run history,
+  never corrupt the file (#38).
+
 ## [1.1.0]
 
 ### Added
@@ -618,7 +634,8 @@ Backup Server, all from a web UI.
 - Config-driven via `config.yaml` (pydantic-validated); secrets stay in `config.yaml` and are
   redacted from API responses.
 
-[Unreleased]: https://github.com/Joulenap/joulenap/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/Joulenap/joulenap/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/Joulenap/joulenap/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Joulenap/joulenap/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Joulenap/joulenap/compare/v0.9.0...v1.0.0
 [0.9.0]: https://github.com/Joulenap/joulenap/compare/v0.8.0...v0.9.0

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Joulenap **owns the schedule** itself (internal scheduler), so nothing on the Pr
 
 ## Status
 
-**v1.1.0.** Built around routes over any number of PVE and PBS devices: backup, PBS→PBS sync,
+**v1.1.1.** Built around routes over any number of PVE and PBS devices: backup, PBS→PBS sync,
 external-schedule watching and verification, driven by a run queue and a per-server power lease
 so a box is woken once and slept once no matter how many routes need it. Packaged as a Docker
 image, with transport hardening (per-device PBS TLS pinning + SSH host-key verification) and auth

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 """Joulenap — web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -39,12 +39,20 @@ def _make_engine(db_file: Path):
         #  - WAL lets those readers keep going while the cycle writes, instead of
         #    blocking each other (the default rollback journal serialises them).
         #  - busy_timeout makes a genuinely contended write WAIT rather than fail
-        #    instantly with "database is locked".
+        #    instantly with "database is locked". 30 s, not 5: the writers here are all
+        #    millisecond-long, so a wait that runs out means the *commit* itself stalled
+        #    (an fsync on a slow or busy disk), and a task-log line waiting half a minute
+        #    costs nothing next to a run dying on it.
+        #  - synchronous=NORMAL drops the per-commit fsync (WAL only syncs at checkpoint):
+        #    still safe across an app crash; a power loss can lose the last commits of
+        #    history, never corrupt the file. Full durability of run logs is not worth a
+        #    "database is locked" every time the disk hiccups under a backup.
         #  - foreign_keys makes the ondelete=CASCADE relationships actually enforce
         #    (SQLite leaves FK enforcement off by default).
         cur = dbapi_conn.cursor()
         cur.execute("PRAGMA journal_mode=WAL")
-        cur.execute("PRAGMA busy_timeout=5000")
+        cur.execute("PRAGMA busy_timeout=30000")
+        cur.execute("PRAGMA synchronous=NORMAL")
         cur.execute("PRAGMA foreign_keys=ON")
         cur.close()
 

--- a/backend/app/jobs/service.py
+++ b/backend/app/jobs/service.py
@@ -22,12 +22,13 @@ from collections import deque
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from ..config import Config, PbsDevice, Route
 from ..core.config_store import ConfigStore
 from ..db import session_scope
-from ..db.models import LogLevel, RunKind, RunStatus, RunTrigger, StepName, StepStatus
+from ..db.models import LogLevel, Run, RunKind, RunStatus, RunTrigger, StepName, StepStatus
 from ..db.prune import PruneResult, prune_history
 from ..notify.messages import LocalizedError, RunContext
 from .deps import CycleDeps
@@ -302,7 +303,30 @@ class JobService:
         subject, devices = resolved
 
         route = subject if isinstance(subject, Route) else None
-        recorder = self._start(item.kind, item.trigger, route)
+        try:
+            recorder = self._start(item.kind, item.trigger, route)
+        except Exception as exc:
+            # The run could not even write its own row (a locked database past the busy
+            # timeout, a full disk). Without this it vanished: no history row, no
+            # notification, one line in the container log. Say so on the configured
+            # channels with an unsaved Run (the message renders without a run number).
+            log.exception("Run for '%s' could not start", item.key)
+            now = datetime.now(UTC)
+            run = Run(
+                kind=item.kind,
+                trigger=item.trigger,
+                status=RunStatus.FAILURE,
+                route_id=route.id if route else None,
+                route_name=(route.name or route.id) if route else None,
+                started_at=now,
+                finished_at=now,
+                error=f"run could not start: {exc}",
+            )
+            try:
+                self.deps.notify(RunContext(config=config, run=run, route=route))
+            except Exception:  # noqa: BLE001 - nothing left to record it on
+                log.exception("Notification for the run that could not start failed too")
+            return
         item.run_id = recorder.run_id
         held: list[PbsDevice] = []
         multi = len(devices) > 1  # labels every WAIT/POWEROFF step of this run, consistently
@@ -499,9 +523,7 @@ class JobService:
 
     # --- internals -----------------------------------------------------------
 
-    def _start(
-        self, kind: RunKind, trigger: RunTrigger, route: Route | None
-    ) -> RunRecorder:
+    def _start(self, kind: RunKind, trigger: RunTrigger, route: Route | None) -> RunRecorder:
         """Wait for the single-run lock and create the run row. Caller owns the lock.
 
         Blocking is the point: the queue worker's whole job is to wait its turn. Anything

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "joulenap"
-version = "1.1.0"
+version = "1.1.1"
 description = "Self-hosted web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."
 requires-python = ">=3.12"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -28,7 +28,10 @@ def test_sqlite_pragmas_applied(temp_db):
     with session_scope() as s:
         assert s.execute(text("PRAGMA journal_mode")).scalar() == "wal"
         assert s.execute(text("PRAGMA foreign_keys")).scalar() == 1
-        assert s.execute(text("PRAGMA busy_timeout")).scalar() == 5000
+        assert s.execute(text("PRAGMA busy_timeout")).scalar() == 30000
+        # 1 = NORMAL: no fsync per commit; in WAL a stalled disk must not turn a
+        # task-log line into "database is locked" (#38).
+        assert s.execute(text("PRAGMA synchronous")).scalar() == 1
 
 
 def test_create_run_with_logs(temp_db):

--- a/backend/tests/test_service.py
+++ b/backend/tests/test_service.py
@@ -307,3 +307,31 @@ def test_a_stale_cancel_does_not_kill_the_next_run(temp_config, temp_db):
     with session_scope() as session:
         statuses = {r.route_id: r.status for r in session.scalars(select(Run))}
     assert statuses["offsite"] == RunStatus.SUCCESS
+
+
+def test_a_run_that_cannot_write_its_row_is_still_notified(temp_config, temp_db, monkeypatch):
+    # A locked database past the busy timeout at run start used to make the run vanish:
+    # no history row, no notification. It still cannot have a row, but it must be reported.
+    from app.jobs import service as service_mod
+
+    sent = []
+    box = FakeBox()
+    deps, *_ = make_deps(notify=sent.append)
+    service = JobService(ConfigStore.load_or_create(), deps=deps, lease_deps=box.deps())
+
+    def boom(*_a, **_k):
+        raise RuntimeError("database is locked")
+
+    monkeypatch.setattr(service_mod, "RunRecorder", boom)
+    service.run_route("nightly", RunTrigger.SCHEDULED)
+    _drain(service)
+
+    assert len(sent) == 1
+    ctx = sent[0]
+    assert ctx.run.id is None
+    assert ctx.run.status is RunStatus.FAILURE
+    assert ctx.route is not None and ctx.route.id == "nightly"
+    assert "database is locked" in ctx.run.error
+    with session_scope() as session:
+        assert session.execute(select(Run)).scalars().all() == []
+    assert not service.is_running  # the single-run lock was released

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joulenap-frontend",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joulenap-frontend",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/lang-yaml": "^6.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joulenap-frontend",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/devStub.ts
+++ b/frontend/src/devStub.ts
@@ -822,11 +822,11 @@ function demoRoute(key: string, search: URLSearchParams, init?: RequestInit): un
     // The stub's "-stub" marker and its pending-update badge are dev affordances; a public
     // demo should look like a current, healthy install.
     case 'GET /health':
-      return { status: 'ok', version: '1.1.0' }
+      return { status: 'ok', version: '1.1.1' }
     case 'GET /update':
       return {
-        current: '1.1.0',
-        latest: '1.1.0',
+        current: '1.1.1',
+        latest: '1.1.1',
         update_available: false,
         url: 'https://github.com/Joulenap/joulenap/releases',
       }
@@ -1081,10 +1081,10 @@ const WIZARD_WOL_TEST: { sent: boolean; mac: string; broadcast: string } = {
 }
 
 const ROUTES: Record<string, unknown> = {
-  'GET /health': { status: 'ok', version: '1.1.0-stub' },
+  'GET /health': { status: 'ok', version: '1.1.1-stub' },
   'GET /update': {
-    current: '1.1.0-stub',
-    latest: '1.1.0',
+    current: '1.1.1-stub',
+    latest: '1.1.1',
     update_available: true,
     url: 'https://github.com/Joulenap/joulenap/releases',
   },


### PR DESCRIPTION
Patch release for #38, follow-up to 1.1.0.

### Fixed
- A run that could not create its own history row (SQLite `database is locked` past the busy timeout, a full disk) used to vanish: no row, no notification, one line in the container log, so a scheduled sync looked as if it had never fired. It is now reported on the configured notification channels as a failed run (without a run number) and the single-run lock is released as usual.
- The SQLite database now uses `synchronous=NORMAL` with WAL, so a commit no longer fsyncs on every task-log line, and the busy timeout is 30 s instead of 5 s. A disk that stalls for a few seconds under a running backup no longer turns a task-log write into `database is locked` and a failed run. In WAL this remains safe across an application crash; a power loss can at worst lose the last few seconds of run history, never corrupt the file.

Refs #38.
