### PR TITLE
Close the test-suite audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,10 @@ jobs:
       - name: Test (pytest)
         run: pytest --cov=app --cov-report=lcov --cov-fail-under=94
 
-      # One upload per commit is enough; the 3.13 leg exists for compat, not coverage.
+      # One upload per commit is enough, and it comes from the version the image ships:
+      # the other legs are compatibility checks, and the same figure three times would just
+      # race itself. Gated on the step above passing, so a run that trips --cov-fail-under
+      # leaves the badge on the last good commit rather than publishing the dip.
       - name: Upload coverage (Coveralls)
         if: matrix.python-version == '3.12'
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        # 3.12 is what the image ships; 3.13 and 3.14 are compatibility legs, and 3.14 is
+        # what development actually happens on, so it should not be the untested one.
+        python-version: ["3.12", "3.13", "3.14"]
     defaults:
       run:
         working-directory: backend
@@ -73,8 +75,10 @@ jobs:
       - name: Lint (ruff)
         run: ruff check .
 
+      # --cov-fail-under: coverage sat at 96% with no gate at all, so a change could quietly
+      # take it back down. 94 leaves room for a legitimate dip without letting one slide.
       - name: Test (pytest)
-        run: pytest --cov=app --cov-report=lcov
+        run: pytest --cov=app --cov-report=lcov --cov-fail-under=94
 
       # One upload per commit is enough; the 3.13 leg exists for compat, not coverage.
       - name: Upload coverage (Coveralls)
@@ -102,7 +106,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build (tsc --noEmit && vite build)
+      # npm run build now type-checks the tests too (tsconfig.test.json), which tsconfig.json
+      # used to exclude.
+      - name: Build (typecheck + vite build)
         run: npm run build
 
       - name: Test (node --test)

--- a/backend/tests/fakes.py
+++ b/backend/tests/fakes.py
@@ -263,6 +263,10 @@ class FakeBox:
         self.wol: list[str] = []  # pbs ids a magic packet was sent to, in order
         self.waits: list[float] = []  # the timeout of every reachability probe
         self.poweroffs: list[str] = []  # pbs ids actually powered off
+        # Recorded rather than proved by raising: the lease swallows idle-check errors on
+        # purpose (a flaky check must not keep a box awake), so an exception here produces
+        # the same outcome as a successful check and cannot show whether it was skipped.
+        self.idle_checks: list[str] = []
 
     def _answer(self) -> bool:
         if isinstance(self._reachable, list):
@@ -279,7 +283,8 @@ class FakeBox:
         def send_wol(pbs) -> None:
             self.wol.append(pbs.id)
 
-        def wait_idle(_pbs) -> bool:
+        def wait_idle(pbs) -> bool:
+            self.idle_checks.append(pbs.id)
             if self.idle_error is not None:
                 raise self.idle_error
             return self.idle

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -60,16 +60,66 @@ def _wait_run(client, run_id, *, timeout=5.0):
 # --- auth guard --------------------------------------------------------------
 
 
-def test_protected_endpoints_require_auth(temp_config, temp_db):
+#: The only endpoints that may answer an unauthenticated caller, and why.
+#:   health      the container probe, before any account exists
+#:   auth/status what the SPA asks to decide between login and the setup wizard
+#:   auth/setup  first-run account creation (refused once an account exists)
+#:   login       obviously
+#:   logout      clearing a cookie you may not have is harmless
+#:   dashboard   guarded by the API key instead of the session (403 when unconfigured)
+PUBLIC_OPERATIONS = {
+    ("GET", "/api/health"),
+    ("GET", "/api/auth/status"),
+    ("POST", "/api/auth/setup"),
+    ("POST", "/api/login"),
+    ("POST", "/api/logout"),
+    ("GET", "/api/dashboard"),
+}
+
+_PATH_PARAMS = {
+    "pbs_id": "pbs-01", "pve_id": "pve-alpha", "device_id": "pbs-01",
+    "kind": "pbss", "action": "gc", "route_id": "nightly", "run_id": "1",
+}
+
+
+def _operations(app) -> list[tuple[str, str]]:
+    """Every (method, path) FastAPI serves under /api, read off the app itself."""
+    return [
+        (method.upper(), path)
+        for path, operations in app.openapi()["paths"].items()
+        for method in operations
+        if method in {"get", "post", "put", "delete", "patch"}
+    ]
+
+
+def test_every_endpoint_requires_auth_unless_it_is_deliberately_public(temp_config, temp_db):
+    """Enumerated from the route table, not from a hand-kept list.
+
+    The list version covered 22 of the 50 operations, so a new endpoint could ship
+    unprotected without failing anything. Anything not named in PUBLIC_OPERATIONS has to
+    answer 401, and adding an endpoint means either protecting it or saying here why not.
+    """
+    app = create_app()
+    with TestClient(app) as client:
+        operations = _operations(app)
+        assert len(operations) > 40, "the route table looks wrong, not the auth guard"
+
+        for method, path in operations:
+            if (method, path) in PUBLIC_OPERATIONS:
+                continue
+            url = path
+            for name, value in _PATH_PARAMS.items():
+                url = url.replace("{" + name + "}", value)
+            assert "{" not in url, f"unmapped path parameter in {path}"
+            response = client.request(method, url, json={})
+            assert response.status_code == 401, f"{method} {path} answered {response.status_code}"
+
+
+def test_the_public_endpoints_are_still_reachable_without_a_session(temp_config, temp_db):
+    # The other half: an over-eager guard that 401s the login form would lock everyone out.
     with TestClient(create_app()) as client:
-        for path in ("/api/status", "/api/config", "/api/guests", "/api/runs",
-                     "/api/logs", "/api/tasklog", "/api/routes", "/api/devices"):
-            assert client.get(path).status_code == 401, path
-        for path in ("/api/routes", "/api/routes/nightly/run", "/api/runs/1/stop",
-                     "/api/devices/pbss", "/api/devices/pbss/pbs-01/power",
-                     "/api/devices/pbss/pbs-01/gc", "/api/devices/pbss/pbs-01/test",
-                     "/api/notify/test", "/api/scheduler/toggle", "/api/wizard/wol/test"):
-            assert client.post(path).status_code == 401, path
+        assert client.get("/api/health").status_code == 200
+        assert client.get("/api/auth/status").status_code == 200
 
 
 def test_login_locks_out_after_repeated_failures(app_ctx):
@@ -959,3 +1009,31 @@ def test_run_history_falls_back_to_the_stored_english_error(app_ctx):
         run_id = run.id
 
     assert client.get(f"/api/runs/{run_id}").json()["error"] == "vzdump exited with code 255"
+
+
+# --- bcrypt's 72-byte boundary ------------------------------------------------
+
+
+def test_a_password_longer_than_bcrypt_accepts_still_round_trips():
+    """bcrypt truncates at 72 bytes, and hash_password does it explicitly so the behaviour
+    is the same everywhere, including the hashpw CLI. The constant is load-bearing: with a
+    different cut, a password hashed by one path would not verify through the other."""
+    from app.core.security import _BCRYPT_MAX_BYTES, hash_password, verify_password
+
+    assert _BCRYPT_MAX_BYTES == 72
+    long_password = "a" * 100
+    stored = hash_password(long_password)
+
+    assert verify_password(long_password, stored) is True
+    # Everything past byte 72 is invisible to bcrypt, so these are the same password.
+    assert verify_password("a" * 72, stored) is True
+    assert verify_password("a" * 71, stored) is False
+
+
+def test_a_multibyte_password_is_cut_on_bytes_not_characters():
+    # "é" is two bytes in UTF-8, so a character-based cut would produce a different hash
+    # than bcrypt's own and logins would fail for anyone with a long accented password.
+    from app.core.security import hash_password, verify_password
+
+    stored = hash_password("é" * 40)  # 80 bytes, truncated to 72 => 36 characters
+    assert verify_password("é" * 36, stored) is True

--- a/backend/tests/test_api_devices.py
+++ b/backend/tests/test_api_devices.py
@@ -446,3 +446,17 @@ def test_keep_on_leaves_the_box_awake(app_ctx):
     _drain(app)
 
     assert box.poweroffs == []
+
+
+def test_maintenance_with_no_body_powers_the_box_back_off(app_ctx):
+    """The default half of ``keep_on``, and the reason this app exists: the "Run GC" button
+    sends no body, so the model default is what decides whether the box goes back to sleep.
+    Flipping it to True left every ad-hoc run's box awake with nothing failing."""
+    client, app = app_ctx
+    box = FakeBox()
+    _inject(app, box=box)
+
+    assert client.post("/api/devices/pbss/pbs-01/gc").status_code == 202
+    _drain(app)
+
+    assert box.poweroffs == ["pbs-01"]

--- a/backend/tests/test_api_devices.py
+++ b/backend/tests/test_api_devices.py
@@ -234,6 +234,64 @@ def test_test_502s_when_the_device_cannot_be_reached(app_ctx):
 # --- storage re-read ----------------------------------------------------------
 
 
+def test_list_storages_reports_what_the_pve_actually_has(app_ctx):
+    """The read half of the storages pair, and the whole handler was untested.
+
+    The wizard asks this before minting a token, because the answer decides whether
+    replacing an API token on that backup server would break a storage entry nobody would
+    think to look at. Nothing is written.
+    """
+    client, app = app_ctx
+    _inject(
+        app,
+        pves={
+            "pve-beta": FakePve(
+                pbs_storages=[
+                    {
+                        "storage": "pbs-offsite",
+                        "server": "192.0.2.21",
+                        "datastore": "offsite",
+                        "fingerprint": "AA:BB",
+                    }
+                ]
+            )
+        },
+    )
+
+    r = client.get("/api/devices/pves/pve-beta/storages")
+
+    assert r.status_code == 200
+    assert r.json() == [
+        {
+            "storage": "pbs-offsite",
+            "host": "192.0.2.21",
+            "port": 8007,
+            "datastore": "offsite",
+            "fingerprint": "AA:BB",
+        }
+    ]
+    # Read-only: the stored map is untouched, unlike the POST sibling below.
+    stored = next(p for p in load_config().pves if p.id == "pve-beta")
+    assert stored.storages == {"pbs-01": "pbs"}
+
+
+def test_list_storages_404s_on_an_unknown_pve(app_ctx):
+    client, _app = app_ctx
+    assert client.get("/api/devices/pves/nope/storages").status_code == 404
+
+
+def test_list_storages_reports_an_unreachable_pve_as_502(app_ctx):
+    # 502 and not 500: the wizard shows "could not reach this host", which is actionable,
+    # rather than an internal error the user can do nothing about.
+    client, app = app_ctx
+    _inject(app, pves={"pve-beta": UnreachablePve()})
+
+    r = client.get("/api/devices/pves/pve-beta/storages")
+
+    assert r.status_code == 502
+    assert "connection refused" in r.json()["detail"]
+
+
 def test_refresh_storages_links_a_backup_server_added_later(app_ctx):
     """The reason this endpoint exists: register a backup server *after* the Proxmox host
     that backs up to it and nothing could complete the map — the Add-PVE wizard refuses a

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import pytest
-from fakes import FakeBox, make_deps
+from fakes import FakeBox, FakePve, make_deps
 from fastapi.testclient import TestClient
 
 from app.config import load_config
+from app.connectors.pve import Guest
 from app.jobs import JobService
 from app.main import create_app
 
@@ -204,6 +205,47 @@ def test_run_queues_the_route(app_ctx):
     assert r.status_code == 202
     assert r.json() == {"route_id": "nightly", "queued": 0}
     _drain(app)
+
+
+def _inject_box(app) -> FakeBox:
+    """Re-wire the job service onto a FakeBox we keep a handle on, to read poweroffs.
+
+    Both sources get a guest: a source with nothing to back up fails, and a failed run
+    deliberately leaves the box on, which would mask what these tests are asking about.
+    """
+    box = FakeBox()
+    guest = Guest(vmid=100, name="ct", type="lxc", status="running", node="n1")
+    deps, *_ = make_deps(
+        pves={"pve-alpha": FakePve(guests=[guest]), "pve-beta": FakePve(guests=[guest])}
+    )
+    app.state.job_service = JobService(
+        app.state.config_store, deps=deps, lease_deps=box.deps()
+    )
+    return box
+
+
+def test_a_run_with_no_body_powers_the_pbs_back_off(app_ctx):
+    """The default half of ``keep_on``. Posting *no body* is what the dashboard's Run
+    button does, so this is the path that decides whether the box goes back to sleep, and
+    nothing pinned it: flipping ``keep_on`` to True left every manual run's target awake
+    and the suite stayed green."""
+    client, app = app_ctx
+    box = _inject_box(app)
+
+    assert client.post("/api/routes/nightly/run").status_code == 202
+    _drain(app)
+
+    assert box.poweroffs == ["pbs-01"]
+
+
+def test_a_run_asking_to_keep_the_pbs_on_leaves_it_awake(app_ctx):
+    client, app = app_ctx
+    box = _inject_box(app)
+
+    assert client.post("/api/routes/nightly/run", json={"keep_on": True}).status_code == 202
+    _drain(app)
+
+    assert box.poweroffs == []
 
 
 def test_run_404s_on_an_unknown_route(app_ctx):

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -94,7 +94,7 @@ def test_create_rejects_a_backup_route_with_no_storage_mapping(app_ctx):
 
 
 def test_create_rejects_a_cron_the_model_cannot_catch(app_ctx, temp_config):
-    """It wouldn't crash arming — but the route would silently never fire, which is worse.
+    """It wouldn't crash arming, but the route would silently never fire, which is worse.
 
     ``0 4 * * 8`` is deliberately *well-formed*: five fields, so ``RouteSchedule`` accepts it
     and only ``check_route_crons`` (BE-B1) can reject it. A 4-field string never reaches the

--- a/backend/tests/test_api_routes.py
+++ b/backend/tests/test_api_routes.py
@@ -37,6 +37,10 @@ def _armed(app) -> set[str]:
     return set(app.state.scheduler.armed_route_ids())
 
 
+def _route(config, route_id: str):
+    return next(r for r in config.routes if r.id == route_id)
+
+
 # --- read ---------------------------------------------------------------------
 
 
@@ -88,14 +92,62 @@ def test_create_rejects_a_backup_route_with_no_storage_mapping(app_ctx):
     assert "storage" in str(r.json()["detail"])
 
 
-def test_create_rejects_an_unparseable_cron(app_ctx, temp_config):
-    # It wouldn't crash arming — but the route would silently never fire, which is worse.
+def test_create_rejects_a_cron_the_model_cannot_catch(app_ctx, temp_config):
+    """It wouldn't crash arming — but the route would silently never fire, which is worse.
+
+    ``0 4 * * 8`` is deliberately *well-formed*: five fields, so ``RouteSchedule`` accepts it
+    and only ``check_route_crons`` (BE-B1) can reject it. A 4-field string never reaches the
+    guard, so testing with one proves the model validator and nothing else.
+    """
     client, _app = app_ctx
-    body = {**NEW_ROUTE, "schedule": {"cron": "0 4 * *"}}
+    body = {**NEW_ROUTE, "schedule": {"cron": "0 4 * * 8"}}  # day-of-week 8 does not exist
     r = client.post("/api/routes", json=body)
+    assert r.status_code == 422
+    detail = str(r.json()["detail"])
+    assert "invalid schedule.cron" in detail  # the guard's own wording, not pydantic's
+    assert "0 4 * * 8" in detail
+    assert len(load_config(temp_config).routes) == 3
+
+
+def test_create_still_rejects_a_cron_with_the_wrong_field_count(app_ctx, temp_config):
+    # The model validator's half of the same contract, kept separate so neither can mask
+    # the other going missing.
+    client, _app = app_ctx
+    r = client.post("/api/routes", json={**NEW_ROUTE, "schedule": {"cron": "0 4 * *"}})
     assert r.status_code == 422
     assert "schedule.cron" in str(r.json()["detail"])
     assert len(load_config(temp_config).routes) == 3
+
+
+def test_an_unchanged_bad_cron_does_not_block_an_unrelated_edit(app_ctx, temp_config):
+    """The "changed-only" half of the guard: a legacy string already on disk must not lock
+    the user out of Settings. Written straight to the store because the API would refuse it."""
+    client, app = app_ctx
+    app.state.config_store.update(
+        lambda c: setattr(_route(c, "nightly").schedule, "cron", "0 4 * * 8")
+    )
+
+    body = client.get("/api/routes").json()[0]
+    body["name"] = "Nightly renamed"
+    assert client.put("/api/routes/nightly", json=body).status_code == 200
+
+    saved = _route(load_config(temp_config), "nightly")
+    assert saved.name == "Nightly renamed"
+    assert saved.schedule.cron == "0 4 * * 8"  # carried through, still saveable
+
+
+def test_changing_a_bad_cron_to_another_bad_one_is_rejected(app_ctx):
+    # Unchanged is grandfathered; *edited* is not, or the escape hatch would become a hole.
+    client, app = app_ctx
+    app.state.config_store.update(
+        lambda c: setattr(_route(c, "nightly").schedule, "cron", "0 4 * * 8")
+    )
+
+    body = client.get("/api/routes").json()[0]
+    body["schedule"]["cron"] = "0 99 * * *"
+    r = client.put("/api/routes/nightly", json=body)
+    assert r.status_code == 422
+    assert "invalid schedule.cron" in str(r.json()["detail"])
 
 
 # --- update -------------------------------------------------------------------

--- a/backend/tests/test_api_wizard.py
+++ b/backend/tests/test_api_wizard.py
@@ -278,3 +278,86 @@ def test_wol_test_falls_back_to_the_global_broadcast_without_a_host(client, monk
 
     assert resp.status_code == 200
     assert sent == [("00:11:22:33:44:55", "255.255.255.255")]
+
+
+# --- request-model defaults ---------------------------------------------------
+#
+# Every field below is a default the UI relies on by *omitting* it. Nothing pinned them,
+# so the whole of api/wizard.py could be mutated freely without a single failure: a
+# replace_token defaulting to True would have silently replaced a token on a live backup
+# server, which is exactly what test_an_existing_token_is_never_replaced_silently guards
+# one layer down.
+
+
+def _capture(monkeypatch, name: str, result: dict) -> dict:
+    """Patch a core-wizard entry point and hand back the kwargs the router forwarded."""
+    captured: dict = {}
+
+    def fake(**kwargs):
+        captured.update(kwargs)
+        return result
+
+    monkeypatch.setattr(wizard, name, fake)
+    return captured
+
+
+def test_pve_connect_defaults_to_the_pve_port_no_tls_and_no_token_replacement(
+    client, monkeypatch
+):
+    captured = _capture(
+        monkeypatch, "pve_connect", {"connected": True, "nodes": [], "storages": [], "token": None}
+    )
+
+    assert client.post("/api/wizard/pve/connect", json={"host": "pve.local"}).status_code == 200
+
+    assert captured["port"] == 8006  # PVE, not the PBS 8007 next door
+    assert captured["verify_tls"] is False  # homelab certs are self-signed
+    assert captured["replace_token"] is False  # never clobber a token unasked
+    assert captured["mode"] == "token"  # the safe mode: no root password involved
+    assert captured["token_name"] == "joulenap"
+
+
+def test_pbs_provision_defaults_to_the_pbs_port_no_tls_and_no_token_replacement(
+    client, monkeypatch
+):
+    captured = _capture(monkeypatch, "pbs_provision", {"id": "root@pam!joulenap", "secret": "s"})
+
+    r = client.post(
+        "/api/wizard/pbs/provision",
+        json={"host": "pbs.local", "password": "pw", "datastore": "backup"},
+    )
+    assert r.status_code == 200
+
+    assert captured["port"] == 8007
+    assert captured["verify_tls"] is False
+    assert captured["replace_token"] is False
+    assert captured["username"] == "root@pam"
+    assert captured["fingerprint"] == ""  # nothing pinned until the check step supplies one
+
+
+def test_pbs_check_defaults_to_the_pbs_port(client, monkeypatch):
+    captured = _capture(monkeypatch, "pbs_check", {"reachable": True, "fingerprint": None})
+
+    assert client.post("/api/wizard/pbs/check", json={"host": "pbs.local"}).status_code == 200
+
+    assert captured["port"] == 8007
+
+
+def test_the_ssh_endpoints_default_to_port_22_and_the_root_user(client, monkeypatch):
+    install = _capture(monkeypatch, "ssh_install", {"installed": True})
+    client.post(
+        "/api/wizard/ssh/install",
+        json={"host": "pbs.local", "password": "pw", "public_key": "ssh-ed25519 AAAA"},
+    )
+    assert install["port"] == 22 and install["user"] == "root"
+
+    hostkey = _capture(monkeypatch, "ssh_hostkey", {"key_type": "ssh-ed25519", "key_base64": "AA"})
+    client.post("/api/wizard/ssh/hostkey", json={"host": "pbs.local"})
+    assert hostkey["port"] == 22
+
+    trust = _capture(monkeypatch, "ssh_trust", {"trusted": True})
+    client.post(
+        "/api/wizard/ssh/trust",
+        json={"host": "pbs.local", "key_type": "ssh-ed25519", "key_base64": "AA"},
+    )
+    assert trust["port"] == 22

--- a/backend/tests/test_api_wizard.py
+++ b/backend/tests/test_api_wizard.py
@@ -361,3 +361,33 @@ def test_the_ssh_endpoints_default_to_port_22_and_the_root_user(client, monkeypa
         json={"host": "pbs.local", "key_type": "ssh-ed25519", "key_base64": "AA"},
     )
     assert trust["port"] == 22
+
+
+def test_storage_derive_and_grant_sync_default_to_no_tls_and_their_own_ports(
+    client, monkeypatch
+):
+    # The two remaining wizard bodies, same contract as the ones above: a UI that omits
+    # these fields must get the permissive-but-deliberate defaults, not whatever a later
+    # edit leaves behind.
+    derive = _capture(monkeypatch, "storage_derive", {"host": "pbs.local", "datastore": "backup"})
+    r = client.post(
+        "/api/wizard/storage/derive",
+        json={
+            "host": "pve.local",
+            "api_token_id": "root@pam!joulenap",
+            "api_token_secret": "sec",
+            "storage_id": "pbs",
+        },
+    )
+    assert r.status_code == 200
+    assert derive["port"] == 8006 and derive["verify_tls"] is False
+
+    grant = _capture(monkeypatch, "pbs_grant_sync", {"token_id": "t", "roles": ["RemoteAudit"]})
+    r = client.post(
+        "/api/wizard/pbs/grant-sync",
+        json={"host": "pbs.local", "password": "pw", "api_token_id": "root@pam!joulenap"},
+    )
+    assert r.status_code == 200
+    assert grant["port"] == 8007 and grant["verify_tls"] is False
+    assert grant["username"] == "root@pam"
+    assert grant["fingerprint"] == ""

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -103,3 +103,46 @@ def test_password_is_hashed_not_plaintext(client, temp_config):
 def test_setup_rejects_short_password(client):
     r = client.post("/api/auth/setup", json={"username": "admin", "password": "1234"})
     assert r.status_code == 422
+
+
+# --- the password-length boundary ---------------------------------------------
+#
+# Eight is the documented minimum, so both sides of it need a test: a nine-character
+# password proves nothing about where the line sits, and "at least 8" quietly becoming
+# "more than 8" would reject the password the setup wizard itself suggests.
+
+
+def test_exactly_eight_characters_is_accepted_at_setup(client):
+    r = client.post("/api/auth/setup", json={"username": "admin", "password": "12345678"})
+    assert r.status_code == 201
+
+
+def test_seven_characters_is_refused_at_setup(client):
+    r = client.post("/api/auth/setup", json={"username": "admin", "password": "1234567"})
+    assert r.status_code == 422
+
+
+def test_exactly_eight_characters_is_accepted_on_an_account_change(client):
+    client.post("/api/auth/setup", json={"username": "admin", "password": "secret12"})
+
+    r = client.put(
+        "/api/account",
+        json={"current_password": "secret12", "username": "admin", "password": "abcdefgh"},
+    )
+
+    assert r.status_code == 200
+    client.post("/api/logout")
+    assert client.post(
+        "/api/login", json={"username": "admin", "password": "abcdefgh"}
+    ).status_code == 200
+
+
+def test_seven_characters_is_refused_on_an_account_change(client):
+    client.post("/api/auth/setup", json={"username": "admin", "password": "secret12"})
+
+    r = client.put(
+        "/api/account",
+        json={"current_password": "secret12", "username": "admin", "password": "abcdefg"},
+    )
+
+    assert r.status_code == 422

--- a/backend/tests/test_config_defaults.py
+++ b/backend/tests/test_config_defaults.py
@@ -1,0 +1,144 @@
+"""What the *model* declares, not what the shipped example happens to say.
+
+Every other test loads ``config.example.yaml`` through the ``temp_config`` fixture, and the
+example spells most of these values out. That makes the pydantic defaults behind them dead
+weight as far as the suite is concerned: flip ``update_check`` to ``True`` in config.py and
+``test_disabled_by_default_never_calls_out`` still passes, because it reads the ``false``
+from the file. These tests construct the models with no YAML anywhere, so the declared
+default is the thing under test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app import paths
+from app.config import (
+    Config,
+    DiscordConfig,
+    EmailConfig,
+    NtfyConfig,
+    PbsDevice,
+    PveDevice,
+    RouteOptions,
+    TelegramConfig,
+)
+
+# --- the defaults that decide what the app does unasked -----------------------
+
+
+def test_no_outbound_call_is_configured_by_default():
+    # The README's promise: Joulenap makes no internet call unless the user opts in.
+    assert Config().app.update_check is False
+
+
+def test_pve_tls_verification_defaults_to_off():
+    # Homelab Proxmox certificates are self-signed, so off is the deliberate default —
+    # but it has to be the *declared* one, not one the example happens to repeat.
+    assert PveDevice(id="pve-01").verify_tls is False
+
+
+def test_a_pbs_pins_nothing_until_it_is_given_a_fingerprint():
+    # PBS has no verify_tls flag: it is pinned by fingerprint or not verified at all
+    # (see jobs/deps._connect_pbs). An empty default is what "not pinned yet" looks like.
+    assert PbsDevice(id="pbs-01", managed_power=False).fingerprint == ""
+
+
+def test_no_notification_channel_is_enabled_by_default():
+    # An enabled channel with no credentials would be attempted on every run and reported
+    # as a failure; worse, a pre-filled one would send somewhere the user never chose.
+    assert TelegramConfig().enabled is False
+    assert NtfyConfig().enabled is False
+    assert EmailConfig().enabled is False
+    assert DiscordConfig().enabled is False
+    assert Config().notifications.custom_urls == []
+
+
+def test_both_routing_toggles_default_to_on():
+    # The inverse risk: a user who configures a channel expects to hear about runs.
+    n = Config().notifications
+    assert (n.on_success, n.on_failure) == (True, True)
+
+
+def test_a_fresh_install_has_no_devices_no_routes_and_an_armed_scheduler():
+    cfg = Config()
+    assert (cfg.pves, cfg.pbss, cfg.routes) == ([], [], [])
+    assert cfg.app.scheduler_enabled is True  # nothing to fire yet, but not pre-disabled
+    assert cfg.app.api_key == ""  # the dashboard integration is off until asked for
+
+
+def test_power_management_defaults_match_what_the_docs_promise():
+    pbs = PbsDevice(id="pbs-01", mac="00:11:22:33:44:55", ssh_key_path="/k")
+    # managed_power on is what makes this a *power-saving* backup tool; the three timings
+    # below are what the wizard shows and INSTALL.md documents.
+    assert pbs.managed_power is True
+    assert (pbs.wait_timeout, pbs.wol_retries, pbs.poweroff_task_wait) == (180, 2, 600)
+    assert pbs.port == 8007
+
+
+def test_route_options_default_to_gc_on_and_verify_off():
+    opts = RouteOptions()
+    assert (opts.gc, opts.verify_after) == (True, False)
+    assert opts.min_free_percent == 0  # the preflight guard is opt-in
+    assert opts.bwlimit == 0  # unlimited
+    assert opts.mode == "snapshot"
+
+
+# --- the example file must not contradict the model ---------------------------
+
+#: The example is documentation as much as config, so a couple of values are deliberately
+#: illustrative rather than default. Everything else drifting is a bug in one of the two.
+_ALLOWED_DIVERGENCE = {
+    "notifications.email.from_addr",  # a sample address, so the form shows the shape
+}
+
+
+def _flatten(node, prefix: str = "") -> dict[str, object]:
+    out: dict[str, object] = {}
+    for key, value in (node or {}).items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            out.update(_flatten(value, path))
+        elif not isinstance(value, list):
+            out[path] = value
+    return out
+
+
+def test_the_example_never_contradicts_a_model_default():
+    """A value spelled out in config.example.yaml and declared in config.py must agree.
+
+    They are two copies of the same decision and only one of them is under test anywhere
+    else, so this is what stops them drifting.
+    """
+    raw = yaml.safe_load(paths.config_example_path().read_text(encoding="utf-8")) or {}
+    example = _flatten(raw)
+    model = _flatten(Config().model_dump(mode="python"))
+
+    drift = {
+        key: (value, model[key])
+        for key, value in example.items()
+        if key in model and key not in _ALLOWED_DIVERGENCE and value != model[key]
+    }
+    assert drift == {}, f"example vs model default: {drift}"
+
+
+def test_the_example_still_loads_and_is_unconfigured():
+    # It is what a first run copies into place, so it has to parse *and* land the user in
+    # the setup wizard rather than in a half-configured app.
+    cfg = _load_example()
+    assert (cfg.pves, cfg.pbss, cfg.routes) == ([], [], [])
+
+
+def _load_example() -> Config:
+    from app.config import load_config
+
+    return load_config(Path(paths.config_example_path()))
+
+
+@pytest.mark.parametrize("field", ["secret_key", "api_key"])
+def test_the_example_ships_no_usable_secret(field: str):
+    # A committed real key would be the same key on every install.
+    assert getattr(_load_example().app, field) in {"", "CHANGE_ME"}

--- a/backend/tests/test_config_defaults.py
+++ b/backend/tests/test_config_defaults.py
@@ -36,7 +36,7 @@ def test_no_outbound_call_is_configured_by_default():
 
 
 def test_pve_tls_verification_defaults_to_off():
-    # Homelab Proxmox certificates are self-signed, so off is the deliberate default —
+    # Homelab Proxmox certificates are self-signed, so off is the deliberate default,
     # but it has to be the *declared* one, not one the example happens to repeat.
     assert PveDevice(id="pve-01").verify_tls is False
 

--- a/backend/tests/test_config_yaml.py
+++ b/backend/tests/test_config_yaml.py
@@ -89,10 +89,24 @@ def test_a_deleted_0_9_section_is_rejected_rather_than_silently_ignored(client):
 
 
 def test_invalid_cron_is_rejected_through_the_yaml_path(client):
-    # Proves the shared guards (BE-B1) still run for the editor. A list value replaces
-    # wholesale, so the route has to be sent in full.
+    """Proves the shared guard (BE-B1) still runs for the editor. A list value replaces
+    wholesale, so the route has to be sent in full.
+
+    ``0 4 * * 8`` has the right field count, so ``RouteSchedule`` lets it through and only
+    ``check_route_crons`` can stop it. With a 4-field string the model rejects it first and
+    this test would pass even with the guard deleted.
+    """
     doc = yaml.safe_load(_text(client))
-    doc["routes"][0]["schedule"]["cron"] = "0 4 * *"  # 4 fields, unparseable
+    doc["routes"][0]["schedule"]["cron"] = "0 4 * * 8"  # 5 fields, day-of-week 8
+    resp = _put(client, yaml.safe_dump({"routes": doc["routes"]}))
+    assert resp.status_code == 422
+    assert "invalid schedule.cron" in resp.json()["detail"]["message"]
+
+
+def test_a_cron_with_the_wrong_field_count_is_rejected_through_the_yaml_path(client):
+    # The model validator's half, so removing either guard fails a test of its own.
+    doc = yaml.safe_load(_text(client))
+    doc["routes"][0]["schedule"]["cron"] = "0 4 * *"
     resp = _put(client, yaml.safe_dump({"routes": doc["routes"]}))
     assert resp.status_code == 422
     assert "schedule.cron" in resp.json()["detail"]["message"]

--- a/backend/tests/test_discovery.py
+++ b/backend/tests/test_discovery.py
@@ -130,3 +130,69 @@ def test_match_skips_storages_no_registered_device_claims():
         [_storage("stranger", "192.0.2.99", "backup")], [_Pbs("pbs-01", "192.0.2.20", "backup")]
     )
     assert linked == {}
+
+
+# --- the real /proc/net/arp parser -------------------------------------------
+#
+# detect_mac's tests inject `read_arp_table`, so the default implementation behind that
+# seam had never run. It is the half that actually decides whether Wake-on-LAN can be set
+# up from the wizard, and it fails by returning {} rather than by raising.
+
+
+def _arp_file(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "arp"
+    path.write_text(
+        "IP address       HW type     Flags       HW address            Mask     Device\n" + body,
+        encoding="ascii",
+    )
+    return path
+
+
+def test_read_proc_arp_parses_a_real_table(tmp_path: Path, monkeypatch):
+    table = _arp_file(
+        tmp_path,
+        "192.168.1.20     0x1         0x2         AA:BB:CC:DD:EE:FF     *        eth0\n"
+        "192.168.1.21     0x1         0x2         11:22:33:44:55:66     *        eth0\n",
+    )
+    monkeypatch.setattr(discovery, "_ARP_PATH", str(table))
+
+    assert discovery._read_proc_arp() == {
+        "192.168.1.20": "aa:bb:cc:dd:ee:ff",  # lowercased, because that is what WoL compares
+        "192.168.1.21": "11:22:33:44:55:66",
+    }
+
+
+def test_read_proc_arp_skips_incomplete_and_zero_entries(tmp_path: Path, monkeypatch):
+    # Flags 0x0 means the kernel asked but got no answer, and the placeholder MAC that
+    # comes with it would be sent a magic packet that reaches nobody.
+    table = _arp_file(
+        tmp_path,
+        "192.168.1.30     0x1         0x0         00:00:00:00:00:00     *        eth0\n"
+        "192.168.1.31     0x1         0x2         00:00:00:00:00:00     *        eth0\n"
+        "192.168.1.32     0x1         0x2         not-a-mac             *        eth0\n"
+        "192.168.1.33     0x1         0x2         AA:BB:CC:DD:EE:FF     *        eth0\n",
+    )
+    monkeypatch.setattr(discovery, "_ARP_PATH", str(table))
+
+    assert discovery._read_proc_arp() == {"192.168.1.33": "aa:bb:cc:dd:ee:ff"}
+
+
+def test_read_proc_arp_is_empty_off_linux(tmp_path: Path, monkeypatch):
+    # No /proc/net/arp (Windows, macOS, a stripped container): empty map, never an
+    # exception, because detect_mac returning None is the supported "we don't know" answer.
+    monkeypatch.setattr(discovery, "_ARP_PATH", str(tmp_path / "does-not-exist"))
+    assert discovery._read_proc_arp() == {}
+
+
+def test_detect_mac_uses_the_real_parser_by_default(tmp_path: Path, monkeypatch):
+    # The wiring itself: detect_mac's default read_arp_table is _read_proc_arp, so a
+    # correct parser and a correct lookup still add up to a MAC.
+    table = _arp_file(
+        tmp_path,
+        "10.0.0.5         0x1         0x2         AA:BB:CC:DD:EE:FF     *        eth0\n",
+    )
+    monkeypatch.setattr(discovery, "_ARP_PATH", str(table))
+
+    mac = detect_mac("pbs.local", prime=lambda _ip, _port: None, resolve=lambda _h: "10.0.0.5")
+
+    assert mac == "aa:bb:cc:dd:ee:ff"

--- a/backend/tests/test_entrypoints.py
+++ b/backend/tests/test_entrypoints.py
@@ -1,0 +1,149 @@
+"""The two module entry points the image and the docs actually invoke.
+
+Neither is imported by the app, so neither had a single line of coverage, and both are
+shipped: ``python -m app.healthcheck`` is the Docker HEALTHCHECK, and
+``python -m app.hashpw`` is what INSTALL.md tells users to run to pre-seed a password.
+A broken healthcheck marks a working container unhealthy; a broken hashpw prints a hash
+that will not log in.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from contextlib import contextmanager
+
+import pytest
+
+from app import hashpw, healthcheck
+from app.core.security import verify_password
+
+# --- healthcheck --------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, status: int):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+
+@contextmanager
+def _urlopen(monkeypatch, result):
+    """Stand in for urllib.request.urlopen; ``result`` is a status or an exception."""
+    seen: dict = {}
+
+    def fake(url, timeout=None):
+        seen.update(url=url, timeout=timeout)
+        if isinstance(result, Exception):
+            raise result
+        return _Resp(result)
+
+    monkeypatch.setattr(healthcheck.urllib.request, "urlopen", fake)
+    yield seen
+
+
+def test_a_200_from_the_local_api_is_healthy(monkeypatch):
+    monkeypatch.setattr(healthcheck, "_port", lambda: 8080)
+    with _urlopen(monkeypatch, 200) as seen:
+        assert healthcheck.main() == 0
+    # Localhost on purpose: the probe runs inside the container, and must not depend on
+    # whatever host or reverse proxy the user put in front of it.
+    assert seen["url"] == "http://127.0.0.1:8080/api/health"
+
+
+def test_a_non_200_is_unhealthy(monkeypatch):
+    monkeypatch.setattr(healthcheck, "_port", lambda: 8080)
+    with _urlopen(monkeypatch, 503):
+        assert healthcheck.main() == 1
+
+
+def test_an_unreachable_api_is_unhealthy_rather_than_a_traceback(monkeypatch):
+    # Docker reads the exit code; an exception escaping here would look like a crashed
+    # probe rather than an unhealthy container.
+    monkeypatch.setattr(healthcheck, "_port", lambda: 8080)
+    with _urlopen(monkeypatch, OSError("connection refused")):
+        assert healthcheck.main() == 1
+
+
+def test_the_probe_follows_the_configured_port(monkeypatch, temp_config):
+    from app.config import load_config, save_config
+
+    cfg = load_config(temp_config)
+    cfg.app.port = 9099
+    save_config(cfg, temp_config)
+
+    with _urlopen(monkeypatch, 200) as seen:
+        assert healthcheck.main() == 0
+    assert ":9099/" in seen["url"]
+
+
+def test_an_unreadable_config_falls_back_to_the_default_port(monkeypatch, tmp_path):
+    # A config the app cannot parse still leaves a container that may be serving on 8080,
+    # so the probe guesses rather than failing outright.
+    monkeypatch.setenv("JOULENAP_CONFIG", str(tmp_path / "missing.yaml"))
+    assert healthcheck._port() == 8080
+
+
+# --- hashpw -------------------------------------------------------------------
+
+
+def test_stdin_mode_prints_a_hash_that_actually_verifies(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("hunter22\n"))
+
+    assert hashpw.main(["--stdin"]) == 0
+
+    printed = capsys.readouterr().out.strip()
+    assert printed.startswith("$2b$")
+    # The point of the tool: the hash it prints has to be one login accepts.
+    assert verify_password("hunter22", printed) is True
+    assert verify_password("wrong", printed) is False
+
+
+def test_stdin_mode_keeps_whitespace_that_is_part_of_the_password(monkeypatch, capsys):
+    # Only the line ending is stripped: a password with a trailing space is a valid one,
+    # and silently trimming it would print a hash the user can never log in with.
+    monkeypatch.setattr(sys, "stdin", io.StringIO("  spaced pass  \r\n"))
+
+    assert hashpw.main(["--stdin"]) == 0
+
+    assert verify_password("  spaced pass  ", capsys.readouterr().out.strip()) is True
+
+
+def test_stdin_mode_refuses_an_empty_password(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "stdin", io.StringIO("\n"))
+
+    assert hashpw.main(["--stdin"]) == 1
+
+    assert "No password" in capsys.readouterr().err
+
+
+def test_the_prompt_path_requires_both_entries_to_match(monkeypatch):
+    entries = iter(["secret12", "secret13"])
+    monkeypatch.setattr(hashpw.getpass, "getpass", lambda _prompt: next(entries))
+
+    with pytest.raises(SystemExit) as exit_info:
+        hashpw.main([])
+
+    assert exit_info.value.code == 1
+
+
+def test_the_prompt_path_refuses_an_empty_password(monkeypatch):
+    monkeypatch.setattr(hashpw.getpass, "getpass", lambda _prompt: "")
+
+    with pytest.raises(SystemExit) as exit_info:
+        hashpw.main([])
+
+    assert exit_info.value.code == 1
+
+
+def test_the_prompt_path_prints_a_verifying_hash(monkeypatch, capsys):
+    monkeypatch.setattr(hashpw.getpass, "getpass", lambda _prompt: "secret12")
+
+    assert hashpw.main([]) == 0
+
+    assert verify_password("secret12", capsys.readouterr().out.strip()) is True

--- a/backend/tests/test_lease.py
+++ b/backend/tests/test_lease.py
@@ -230,12 +230,29 @@ def test_a_failing_idle_check_fails_open():
 
 
 def test_the_idle_check_is_skipped_when_the_wait_is_zero():
-    box = FakeBox(idle_error=RuntimeError("must not be called"))
+    """poweroff_task_wait=0 means "don't ask, just shut it down".
+
+    Asserted on the recorded call, not by raising: a raising check fails open (the test
+    above), so it powers off either way and the assertion could not tell the two apart.
+    """
+    box = FakeBox()
     lease = PowerLease(box.deps())
     pbs = make_pbs(poweroff_task_wait=0)
 
     lease.acquire(pbs)
     assert lease.release(pbs) is ReleaseOutcome.POWERED_OFF
+    assert box.idle_checks == []
+
+
+def test_the_idle_check_runs_when_a_wait_is_configured():
+    # The other side of the same boundary, so neither direction can drift unnoticed.
+    box = FakeBox()
+    lease = PowerLease(box.deps())
+    pbs = make_pbs(poweroff_task_wait=1)
+
+    lease.acquire(pbs)
+    assert lease.release(pbs) is ReleaseOutcome.POWERED_OFF
+    assert box.idle_checks == ["pbs1"]
 
 
 def test_a_failed_power_off_is_swallowed():

--- a/backend/tests/test_lease_deps.py
+++ b/backend/tests/test_lease_deps.py
@@ -1,0 +1,208 @@
+"""The four power operations behind ``LeaseDeps.default()``.
+
+``test_lease.py`` drives the refcounting and the wake/power-off decisions through
+``FakeBox``, which is the right way to test that logic and also means the production
+implementations never ran. These are the functions that turn a ``PbsDevice`` into an actual
+magic packet, an actual TLS-pinned PBS client and an actual SSH poweroff, so a mistake here
+is invisible to every other test and only shows up as a backup server that never wakes or
+never sleeps.
+
+Same shape as ``test_deps.py``: patch the module's own globals, assert the wiring.
+"""
+
+from __future__ import annotations
+
+import ssl
+
+import pytest
+
+from app.config import PbsDevice
+from app.jobs import lease
+
+
+def make_pbs(**over) -> PbsDevice:
+    base = {
+        "id": "pbs-01",
+        "host": "192.0.2.20",
+        "datastore": "backup",
+        "mac": "00:11:22:33:44:55",
+        "api_token_id": "root@pam!joulenap",
+        "api_token_secret": "secret",
+        "ssh_key_path": "/data/id_ed25519",
+    }
+    return PbsDevice(**{**base, **over})
+
+
+def test_default_wires_the_production_implementations():
+    # The dataclass is built by hand, so a field could silently point at the wrong callable.
+    deps = lease.LeaseDeps.default()
+    assert (deps.send_wol, deps.wait_reachable, deps.wait_idle, deps.poweroff) == (
+        lease._send_wol,
+        lease._wait_reachable,
+        lease._wait_idle,
+        lease._poweroff,
+    )
+
+
+# --- wake ---------------------------------------------------------------------
+
+
+def test_send_wol_targets_the_subnet_broadcast_not_the_whole_network(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        lease.net, "wol_target", lambda host, iface: captured.update(host=host, iface=iface)
+        or ("192.0.2.255", "192.0.2.5")
+    )
+    sent = {}
+    monkeypatch.setattr(
+        lease,
+        "send_magic_packet",
+        lambda mac, broadcast, source_ip: sent.update(
+            mac=mac, broadcast=broadcast, source_ip=source_ip
+        ),
+    )
+
+    lease._send_wol(make_pbs(wol_broadcast_iface="eth0"))
+
+    assert captured == {"host": "192.0.2.20", "iface": "eth0"}
+    # The packet is scoped to the PBS's own segment and bound to that NIC's address.
+    assert sent == {
+        "mac": "00:11:22:33:44:55",
+        "broadcast": "192.0.2.255",
+        "source_ip": "192.0.2.5",
+    }
+
+
+def test_wait_reachable_probes_the_devices_own_host_and_port(monkeypatch):
+    captured = {}
+
+    def fake_wait(host, port, timeout, should_cancel=None):
+        captured.update(host=host, port=port, timeout=timeout, cancel=should_cancel)
+        return True
+
+    monkeypatch.setattr(lease.net, "wait_until_reachable", fake_wait)
+
+    def probe() -> bool:
+        return False
+
+    assert lease._wait_reachable(make_pbs(port=8123), 45, probe) is True
+
+    assert captured == {"host": "192.0.2.20", "port": 8123, "timeout": 45, "cancel": probe}
+
+
+def test_wait_reachable_passes_a_zero_timeout_through(monkeypatch):
+    # timeout=0 is the "is it already awake?" single probe the lease takes before any wake;
+    # rewriting it to a default would make every acquire sit through a wake wait.
+    seen = {}
+    monkeypatch.setattr(
+        lease.net,
+        "wait_until_reachable",
+        lambda host, port, timeout, should_cancel=None: seen.update(timeout=timeout) or False,
+    )
+
+    assert lease._wait_reachable(make_pbs(), 0) is False
+    assert seen["timeout"] == 0
+
+
+# --- idle check ---------------------------------------------------------------
+
+
+class _FakePbsClient:
+    """Records how it was built and what timeout the idle check asked for."""
+
+    last: dict = {}
+
+    def __init__(self, **kwargs):
+        _FakePbsClient.last = dict(kwargs)
+        self.waited = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def wait_until_idle(self, timeout):
+        _FakePbsClient.last["idle_timeout"] = timeout
+        return True
+
+
+def test_wait_idle_pins_tls_when_the_device_has_a_fingerprint(monkeypatch):
+    sentinel = ssl.create_default_context()
+    pinned = {}
+    monkeypatch.setattr(
+        lease.tls,
+        "pinned_ssl_context",
+        lambda host, port, fp: pinned.update(host=host, port=port, fp=fp) or sentinel,
+    )
+    monkeypatch.setattr(lease, "PbsClient", _FakePbsClient)
+
+    assert lease._wait_idle(make_pbs(fingerprint="AA:BB:CC")) is True
+
+    assert pinned == {"host": "192.0.2.20", "port": 8007, "fp": "AA:BB:CC"}
+    assert _FakePbsClient.last["verify"] is sentinel
+    # The device's own budget, not a library default: 0 means "don't wait at all".
+    assert _FakePbsClient.last["idle_timeout"] == 600
+
+
+def test_wait_idle_does_not_pin_without_a_fingerprint(monkeypatch):
+    def boom(*_a, **_k):
+        raise AssertionError("must not pin without a fingerprint")
+
+    monkeypatch.setattr(lease.tls, "pinned_ssl_context", boom)
+    monkeypatch.setattr(lease, "PbsClient", _FakePbsClient)
+
+    lease._wait_idle(make_pbs(poweroff_task_wait=90))
+
+    assert _FakePbsClient.last["verify"] is False
+    assert _FakePbsClient.last["idle_timeout"] == 90
+
+
+def test_wait_idle_passes_the_devices_credentials_and_datastore(monkeypatch):
+    monkeypatch.setattr(lease, "PbsClient", _FakePbsClient)
+
+    lease._wait_idle(make_pbs(datastore="offsite"))
+
+    built = _FakePbsClient.last
+    assert built["host"] == "192.0.2.20"
+    assert built["datastore"] == "offsite"
+    assert built["token_id"] == "root@pam!joulenap"
+    assert built["token_secret"] == "secret"
+
+
+# --- power off ----------------------------------------------------------------
+
+
+def test_poweroff_uses_the_devices_ssh_user_and_key(monkeypatch):
+    built = {}
+    calls = []
+
+    class FakePower:
+        def __init__(self, **kwargs):
+            built.update(kwargs)
+
+        def poweroff(self):
+            calls.append("poweroff")
+
+    monkeypatch.setattr(lease, "PbsPower", FakePower)
+
+    lease._poweroff(make_pbs(ssh_user="backup", ssh_key_path="/data/key"))
+
+    assert built == {"host": "192.0.2.20", "user": "backup", "key_path": "/data/key"}
+    assert calls == ["poweroff"]
+
+
+def test_poweroff_lets_the_error_out_for_the_lease_to_swallow(monkeypatch):
+    # PowerLease._power_off is what decides a failed shutdown is non-fatal; this layer must
+    # not swallow it first, or the lease could never report LEFT_ON.
+    class FakePower:
+        def __init__(self, **_kwargs):
+            pass
+
+        def poweroff(self):
+            raise RuntimeError("ssh refused")
+
+    monkeypatch.setattr(lease, "PbsPower", FakePower)
+
+    with pytest.raises(RuntimeError, match="ssh refused"):
+        lease._poweroff(make_pbs())

--- a/backend/tests/test_net.py
+++ b/backend/tests/test_net.py
@@ -93,3 +93,110 @@ def test_wol_target_falls_back_to_host_when_no_subnet_match(monkeypatch):
     dest, source_ip = net.wol_target("192.0.2.213")
     assert dest == "192.0.2.213"
     assert source_ip is None
+
+
+# --- the real NIC enumeration -------------------------------------------------
+#
+# wol_target's tests monkeypatch `net.list_interfaces`, so the psutil walk behind it had
+# never executed. It decides which NIC the magic packet is bound to, and getting it wrong
+# means a packet that never reaches the PBS.
+
+
+class _Stat:
+    def __init__(self, isup: bool):
+        self.isup = isup
+
+
+class _Addr:
+    def __init__(self, family, address, netmask):
+        self.family, self.address, self.netmask = family, address, netmask
+
+
+def _fake_psutil(stats: dict, addrs: dict):
+    class FakePsutil:
+        @staticmethod
+        def net_if_stats():
+            return stats
+
+        @staticmethod
+        def net_if_addrs():
+            return addrs
+
+    return FakePsutil
+
+
+def test_list_interfaces_keeps_only_up_non_loopback_ipv4(monkeypatch):
+    import socket as socket_mod
+
+    monkeypatch.setattr(
+        net,
+        "psutil",
+        _fake_psutil(
+            stats={"eth0": _Stat(True), "eth1": _Stat(False), "lo": _Stat(True)},
+            addrs={
+                "eth0": [
+                    _Addr(socket_mod.AF_INET6, "fe80::1", None),  # not IPv4: WoL is IPv4
+                    _Addr(socket_mod.AF_INET, "192.168.1.10", "255.255.255.0"),
+                ],
+                "eth1": [_Addr(socket_mod.AF_INET, "10.0.0.5", "255.0.0.0")],  # down
+                "lo": [_Addr(socket_mod.AF_INET, "127.0.0.1", "255.0.0.0")],  # loopback
+            },
+        ),
+    )
+
+    ifaces = net.list_interfaces()
+
+    assert [(i.name, i.address, i.netmask) for i in ifaces] == [
+        ("eth0", "192.168.1.10", "255.255.255.0")
+    ]
+    assert ifaces[0].broadcast == "192.168.1.255"
+
+
+def test_list_interfaces_defaults_a_missing_netmask_to_a_single_host(monkeypatch):
+    # psutil can report an IPv4 address with no netmask; /32 is the safe reading, because
+    # guessing a wider subnet would broadcast the packet at machines that are not the PBS.
+    import socket as socket_mod
+
+    monkeypatch.setattr(
+        net,
+        "psutil",
+        _fake_psutil(
+            stats={"eth0": _Stat(True)},
+            addrs={"eth0": [_Addr(socket_mod.AF_INET, "192.168.1.10", None)]},
+        ),
+    )
+
+    assert net.list_interfaces()[0].netmask == "255.255.255.255"
+
+
+def test_list_interfaces_keeps_a_nic_psutil_reports_no_stats_for(monkeypatch):
+    # `name in stats` guards the isup lookup: an interface missing from net_if_stats is
+    # kept rather than dropped, so an unusual NIC never silently disappears.
+    import socket as socket_mod
+
+    monkeypatch.setattr(
+        net,
+        "psutil",
+        _fake_psutil(
+            stats={},
+            addrs={"weird0": [_Addr(socket_mod.AF_INET, "192.168.5.10", "255.255.255.0")]},
+        ),
+    )
+
+    assert [i.name for i in net.list_interfaces()] == ["weird0"]
+
+
+def test_find_interface_reads_the_real_enumeration(monkeypatch):
+    import socket as socket_mod
+
+    monkeypatch.setattr(
+        net,
+        "psutil",
+        _fake_psutil(
+            stats={"eth0": _Stat(True)},
+            addrs={"eth0": [_Addr(socket_mod.AF_INET, "192.168.1.10", "255.255.255.0")]},
+        ),
+    )
+
+    assert net.find_interface("eth0").address == "192.168.1.10"
+    assert net.find_interface("eth9") is None

--- a/backend/tests/test_notify.py
+++ b/backend/tests/test_notify.py
@@ -171,6 +171,39 @@ def test_ntfy_http_uses_insecure_scheme():
     assert _urls(cfg) == ["ntfy://192.168.1.9:8080/t"]
 
 
+def test_email_on_465_uses_implicit_tls():
+    # 465 is implicit TLS: the session is encrypted from the first byte, so the scheme has
+    # to be mailtos and the mode ssl. Only 587 was covered, and this branch decides whether
+    # a password crosses the network in the clear.
+    cfg = _notifications_config()
+    cfg.notifications.email.smtp_port = 465
+
+    url = next(u for u in _urls(cfg) if u.startswith("mailto"))
+
+    assert url.startswith("mailtos://")
+    assert "mode=ssl" in url
+    assert ":465?" in url
+
+
+def test_email_on_a_plain_port_stays_unencrypted_and_says_so():
+    # Port 25 or a LAN relay: no TLS to ask for, so no mode at all rather than a mode the
+    # server would reject. The scheme is the visible difference in the generated URL.
+    cfg = _notifications_config()
+    cfg.notifications.email.smtp_port = 25
+
+    url = next(u for u in _urls(cfg) if u.startswith("mailto"))
+
+    assert url.startswith("mailto://")
+    assert "mode=" not in url
+
+
+def test_email_needs_host_from_and_to_before_it_produces_a_url():
+    for missing in ("smtp_host", "from_addr", "to_addr"):
+        cfg = _notifications_config()
+        setattr(cfg.notifications.email, missing, "")
+        assert not any(u.startswith("mailto") for u in _urls(cfg)), missing
+
+
 # --- messages ----------------------------------------------------------------
 
 
@@ -976,6 +1009,72 @@ def test_failure_sent_when_on_failure_enabled():
     report = _send(svc, cfg, _run(RunStatus.FAILURE, error="boom"))
     assert report.sent is True
     assert "boom" in fake.payload[1]
+
+
+def test_on_failure_off_silences_a_failed_run():
+    cfg = _notifications_config()
+    cfg.notifications.on_failure = False
+    svc = NotificationService(apprise_factory=FakeApprise)
+
+    report = _send(svc, cfg, _run(RunStatus.FAILURE, error="boom"))
+
+    # The whole report, not just `skipped`: the fields are what /api/notify/test and the
+    # run log show, so a wrong channel count or reason is a wrong answer on screen.
+    assert (report.sent, report.channels, report.skipped) == (False, 0, True)
+    assert report.reason == "on_failure disabled"
+
+
+def test_on_failure_off_also_silences_an_aborted_run():
+    # ABORTED is a failure for routing purposes: a run someone stopped, or one that aborted
+    # on a full datastore, follows on_failure and not on_success.
+    cfg = _notifications_config()
+    cfg.notifications.on_failure = False
+    svc = NotificationService(apprise_factory=FakeApprise)
+
+    report = _send(svc, cfg, _run(RunStatus.ABORTED))
+
+    assert report.skipped is True and report.reason == "on_failure disabled"
+
+
+def test_an_aborted_run_is_sent_when_on_failure_is_on():
+    fake = FakeApprise()
+    cfg = _notifications_config()
+    cfg.notifications.on_success = False  # only the failure route can carry this one
+    svc = NotificationService(apprise_factory=lambda: fake)
+
+    assert _send(svc, cfg, _run(RunStatus.ABORTED)).sent is True
+
+
+def test_on_failure_off_does_not_silence_a_successful_run():
+    # The inverse mistake: the two toggles are independent, and muting failures must not
+    # take the success notification with it.
+    fake = FakeApprise()
+    cfg = _notifications_config()
+    cfg.notifications.on_failure = False
+    svc = NotificationService(apprise_factory=lambda: fake)
+
+    assert _send(svc, cfg, _run(RunStatus.SUCCESS)).sent is True
+
+
+def test_on_success_off_reports_the_full_skip_shape():
+    cfg = _notifications_config()
+    cfg.notifications.on_success = False
+    svc = NotificationService(apprise_factory=FakeApprise)
+
+    report = _send(svc, cfg, _run(RunStatus.SUCCESS))
+
+    assert (report.sent, report.channels, report.skipped) == (False, 0, True)
+    assert report.reason == "on_success disabled"
+
+
+def test_failed_channels_are_logged_on_an_alert(caplog):
+    # The twin of test_failed_channels_are_logged_on_a_run, for the startup alerts (a
+    # missed backup, an interrupted run). Same silent-channel problem, separate loop.
+    fake = FakeApprise(fail_urls={"ntfys://ntfy.sh/homelab": "boom"})
+    svc = NotificationService(apprise_factory=lambda: fake)
+    with caplog.at_level(logging.WARNING, logger="app.notify.service"):
+        svc.send_alert(_notifications_config(), "Backup missed", "while the app was down")
+    assert any("ntfy" in r.message and "boom" in r.message for r in caplog.records)
 
 
 # --- who sends it, and when --------------------------------------------------

--- a/backend/tests/test_pbs.py
+++ b/backend/tests/test_pbs.py
@@ -394,14 +394,17 @@ def test_node_status_converts_cpu_fraction_and_memory_bytes_to_percentages():
         return json_data(
             {
                 "cpu": 0.073,  # 7.3% -> 7
-                "memory": {"total": 8_000_000_000, "used": 3_000_000_000},  # 37.5% -> 38
+                # 90%, deliberately not a round third: a percentage computed against the
+                # wrong scale lands on a different integer here rather than rounding back
+                # onto the right answer.
+                "memory": {"total": 10_000_000_000, "used": 9_000_000_000},
                 "uptime": 3600,
             }
         )
 
     load = make_client(handler).node_status()
 
-    assert (load.cpu, load.mem, load.uptime) == (7, 38, 3600)
+    assert (load.cpu, load.mem, load.uptime) == (7, 90, 3600)
 
 
 def test_node_status_survives_a_node_reporting_no_memory():

--- a/backend/tests/test_pbs.py
+++ b/backend/tests/test_pbs.py
@@ -379,3 +379,44 @@ def test_get_fingerprint(monkeypatch):
         "ssl.SSLContext.wrap_socket", lambda self, sock, server_hostname=None: FakeTLS()
     )
     assert get_fingerprint("pbs.local") == expected
+
+
+# --- node status --------------------------------------------------------------
+#
+# FakePbs hands the dashboard a canned NodeLoad, so the real call and its unit conversions
+# had never run. PBS reports cpu as a 0-1 fraction and memory in bytes; the header shows
+# both as whole percentages.
+
+
+def test_node_status_converts_cpu_fraction_and_memory_bytes_to_percentages():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path.endswith("/nodes/localhost/status")
+        return json_data(
+            {
+                "cpu": 0.073,  # 7.3% -> 7
+                "memory": {"total": 8_000_000_000, "used": 3_000_000_000},  # 37.5% -> 38
+                "uptime": 3600,
+            }
+        )
+
+    load = make_client(handler).node_status()
+
+    assert (load.cpu, load.mem, load.uptime) == (7, 38, 3600)
+
+
+def test_node_status_survives_a_node_reporting_no_memory():
+    # Dividing by a zero total would 500 the whole status endpoint over a cosmetic figure.
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return json_data({"cpu": 0.0, "memory": {}, "uptime": 12})
+
+    load = make_client(handler).node_status()
+
+    assert (load.cpu, load.mem, load.uptime) == (0, 0, 12)
+
+
+def test_node_status_raises_when_the_node_returns_nothing():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return json_data(None)
+
+    with pytest.raises(ApiError, match="node status"):
+        make_client(handler).node_status()

--- a/backend/tests/test_pve.py
+++ b/backend/tests/test_pve.py
@@ -280,3 +280,24 @@ def test_http_error_becomes_apierror():
     with pytest.raises(ApiError) as exc:
         make_client(handler).version()
     assert exc.value.status == 401
+
+
+def test_a_plain_400_is_an_error_too():
+    """400 is the boundary of "4xx/5xx is a failure", and PVE returns it for a rejected
+    vzdump parameter. With the comparison one off, a 400 would be parsed as a success and
+    the run would report a backup that never started."""
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="parameter verification failed")
+
+    with pytest.raises(ApiError) as exc:
+        make_client(handler).version()
+    assert exc.value.status == 400
+    assert "parameter verification failed" in str(exc.value)
+
+
+def test_a_399_is_not_treated_as_an_error():
+    # The other side of the same line: a 3xx must not be turned into a failure.
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": {"version": "8.2"}})
+
+    assert make_client(handler).version() == {"version": "8.2"}

--- a/backend/tests/test_queue.py
+++ b/backend/tests/test_queue.py
@@ -554,3 +554,31 @@ def test_a_powered_off_box_is_not_reported_as_left_on(temp_config, temp_db):
 
     assert box.poweroffs == ["pbs1"]
     assert seen[0].left_on == []
+
+
+def test_a_job_that_explodes_still_releases_its_lease(temp_config, temp_db):
+    """The last-resort release in the worker's finally block.
+
+    A job that raises out of the recorder block leaves the leases held, and a held lease is
+    never revisited: the queue moves on and nothing would ever put that box back to sleep.
+    The box itself stays on, which is the documented behaviour for a run that did not
+    succeed, but the *lease* has to be given back or the next run cannot take it either.
+    """
+    service, box = make_service()
+
+    def exploding_job(_config, _subject, _recorder, _deps):
+        raise RuntimeError("job exploded")
+
+    enqueue(service, "r1", exploding_job, trigger=RunTrigger.SCHEDULED)
+    drain(service)
+
+    pbs = next(p for p in service._store.config.pbss if p.id == "pbs1")
+    assert service.lease.state(pbs).holders == 0
+    assert box.poweroffs == []  # a run that failed leaves the box up for inspection
+
+    # And the queue is usable afterwards rather than wedged: the next run takes the lease
+    # and closes the box normally.
+    enqueue(service, "r2", ok_job, trigger=RunTrigger.SCHEDULED)
+    drain(service)
+    assert box.poweroffs == ["pbs1"]
+    assert service.lease.state(pbs).holders == 0

--- a/backend/tests/test_queue.py
+++ b/backend/tests/test_queue.py
@@ -512,3 +512,45 @@ def test_a_run_on_another_pbs_does_not_hold_the_first(temp_config, temp_db):
     drain(service)
 
     assert box.poweroffs == ["pbs1", "pbs2"]
+
+
+def test_a_single_box_run_records_an_unlabelled_power_off_step(temp_config, temp_db):
+    """``multi`` decides whether the POWEROFF step is labelled with a device id.
+
+    A one-box run reads better as a bare "poweroff", and a sync route's two boxes need the
+    labels to be told apart. Only the labelled case was covered, so the boundary that picks
+    between them was free to move.
+    """
+    service, _box = make_service()
+
+    enqueue(service, "r1", ok_job, trigger=RunTrigger.SCHEDULED)
+    drain(service)
+
+    with session_scope() as session:
+        names = {s.name for s in session.scalars(select(Run)).one().steps}
+    assert StepName.POWEROFF in names
+    assert not any(str(n).startswith("poweroff:") for n in names)
+
+
+def test_a_two_box_run_labels_each_power_off_step(temp_config, temp_db):
+    service, _box = make_service()
+
+    enqueue(service, "sync", ok_job, trigger=RunTrigger.SCHEDULED)
+    drain(service)
+
+    with session_scope() as session:
+        names = {s.name for s in session.scalars(select(Run)).one().steps}
+    assert {"poweroff:pbs1", "poweroff:pbs2"} <= names
+
+
+def test_a_powered_off_box_is_not_reported_as_left_on(temp_config, temp_db):
+    # The notification's "left powered on" line is built from the release outcome, so
+    # confusing POWERED_OFF with LEFT_ON would warn about a box that went to sleep fine.
+    service, box = make_service()
+    seen = sent(service)
+
+    enqueue(service, "r1", notifying_job(), trigger=RunTrigger.SCHEDULED)
+    drain(service)
+
+    assert box.poweroffs == ["pbs1"]
+    assert seen[0].left_on == []

--- a/backend/tests/test_ratelimit.py
+++ b/backend/tests/test_ratelimit.py
@@ -23,3 +23,37 @@ def test_success_resets():
     rl.record_failure("3.3.3.3")
     rl.reset("3.3.3.3")
     assert rl.locked_for("3.3.3.3") == 0.0
+
+
+def test_the_lock_is_still_in_force_at_the_last_instant():
+    # <= 0 means "expired", so the boundary matters: an off-by-one either releases a
+    # brute-force lock a second early or holds one that should have lapsed.
+    t = [0.0]
+    rl = LoginRateLimiter(max_failures=1, lockout_seconds=50, now=lambda: t[0])
+    rl.record_failure("4.4.4.4")
+
+    t[0] = 49.9
+    assert rl.locked_for("4.4.4.4") > 0  # still locked
+
+    t[0] = 50.0
+    assert rl.locked_for("4.4.4.4") == 0.0  # exactly expired, not a moment later
+
+
+def test_a_lapsed_lock_starts_a_fresh_streak():
+    # The entry is dropped on expiry, so the next attempt gets the full allowance again
+    # rather than being locked out by one more failure.
+    t = [0.0]
+    rl = LoginRateLimiter(max_failures=2, lockout_seconds=10, now=lambda: t[0])
+    rl.record_failure("5.5.5.5")
+    rl.record_failure("5.5.5.5")
+    assert rl.locked_for("5.5.5.5") == 10.0
+
+    t[0] = 11.0
+    assert rl.locked_for("5.5.5.5") == 0.0
+    rl.record_failure("5.5.5.5")
+    assert rl.locked_for("5.5.5.5") == 0.0  # one failure into a new streak, not locked
+
+
+def test_an_ip_that_never_failed_is_never_locked():
+    rl = LoginRateLimiter(max_failures=1, lockout_seconds=50, now=lambda: 0.0)
+    assert rl.locked_for("6.6.6.6") == 0.0

--- a/backend/tests/test_ratelimit.py
+++ b/backend/tests/test_ratelimit.py
@@ -54,6 +54,22 @@ def test_a_lapsed_lock_starts_a_fresh_streak():
     assert rl.locked_for("5.5.5.5") == 0.0  # one failure into a new streak, not locked
 
 
+def test_the_expiry_instant_clears_the_entry_not_just_the_answer():
+    # locked_for reports 0 either way at the exact instant; what has to happen *as well* is
+    # that the entry is dropped, so the next failure starts a fresh streak instead of
+    # re-locking immediately off the old count.
+    t = [0.0]
+    rl = LoginRateLimiter(max_failures=2, lockout_seconds=50, now=lambda: t[0])
+    rl.record_failure("7.7.7.7")
+    rl.record_failure("7.7.7.7")
+
+    t[0] = 50.0
+    assert rl.locked_for("7.7.7.7") == 0.0
+
+    rl.record_failure("7.7.7.7")
+    assert rl.locked_for("7.7.7.7") == 0.0  # one of two, not locked again
+
+
 def test_an_ip_that_never_failed_is_never_locked():
     rl = LoginRateLimiter(max_failures=1, lockout_seconds=50, now=lambda: 0.0)
     assert rl.locked_for("6.6.6.6") == 0.0

--- a/backend/tests/test_recorder.py
+++ b/backend/tests/test_recorder.py
@@ -247,3 +247,46 @@ def test_a_run_whose_session_died_is_still_closed_out(temp_db):
     assert len(factory_calls) == 2  # the fallback session
     status, _steps = _run_status(rec.run_id)
     assert status == RunStatus.FAILURE  # not RUNNING: no zombie for the restart sweep
+
+
+def test_a_localized_error_stores_its_key_and_params(temp_db):
+    """error_key/error_params are what the notification layer translates from, so both have
+    to survive the round trip: the key selects the sentence, the params fill it in."""
+    from app.notify.messages import LocalizedError
+
+    with RunRecorder(RunKind.CYCLE, RunTrigger.MANUAL) as recorder:
+        run_id = recorder.run_id
+        recorder.finish(RunStatus.ABORTED, error=LocalizedError("no_storage_mapping", pve="pve-1"))
+
+    with session_scope() as session:
+        run = session.get(Run, run_id)
+        assert run.error_key == "no_storage_mapping"
+        assert json.loads(run.error_params) == {"pve": "pve-1"}
+
+
+def test_an_exception_from_a_library_lands_under_unexpected_with_its_text(temp_db):
+    # Someone else's exception has no key of its own: a translated frame around a verbatim
+    # payload, rather than an untranslated traceback in the notification.
+    with RunRecorder(RunKind.CYCLE, RunTrigger.MANUAL) as recorder:
+        run_id = recorder.run_id
+        recorder.finish(RunStatus.FAILURE, error=RuntimeError("boom"))
+
+    with session_scope() as session:
+        run = session.get(Run, run_id)
+        assert run.error == "boom"
+        assert run.error_key == "unexpected"
+        assert json.loads(run.error_params) == {"detail": "boom"}
+
+
+def test_a_plain_string_error_stores_no_key_and_no_params(temp_db):
+    # The third branch: raw text keeps the pre-i18n behaviour, stored and rendered as-is,
+    # and must leave error_params NULL so nothing tries to json.loads it.
+    with RunRecorder(RunKind.CYCLE, RunTrigger.MANUAL) as recorder:
+        run_id = recorder.run_id
+        recorder.finish(RunStatus.FAILURE, error="something went wrong")
+
+    with session_scope() as session:
+        run = session.get(Run, run_id)
+        assert run.error == "something went wrong"
+        assert run.error_key is None
+        assert run.error_params is None

--- a/backend/tests/test_route_backup.py
+++ b/backend/tests/test_route_backup.py
@@ -341,6 +341,84 @@ def test_no_precheck_step_when_the_guard_is_off(temp_db):
     assert "precheck" not in steps
 
 
+def test_preflight_accepts_a_datastore_sitting_exactly_on_the_threshold(temp_db):
+    # "less than this percentage free" is exclusive: the fake reports 75% free, so a 75%
+    # guard is satisfied. An off-by-one here aborts backups on a datastore that is fine.
+    config = _config()
+    config.routes[0].options.min_free_percent = 75
+    deps, alpha, _beta, _pbs = _deps()
+
+    status, steps = _load(_run(config, deps))
+
+    assert status == RunStatus.SUCCESS
+    assert steps["precheck"] == "success"
+    assert len(alpha.vzdump_calls) == 3
+
+
+def test_preflight_aborts_one_point_below_the_threshold(temp_db):
+    config = _config()
+    config.routes[0].options.min_free_percent = 76
+    deps, alpha, _beta, _pbs = _deps()
+
+    status, _steps = _load(_run(config, deps))
+
+    assert status == RunStatus.ABORTED
+    assert alpha.vzdump_calls == []
+
+
+# --- aborts before anything runs ----------------------------------------------
+#
+# Config validation should make these unreachable, so they are the belt to that braces:
+# they exist for a config edited by hand or a device deleted mid-flight, and each aborts
+# the run with a named reason instead of raising something the UI cannot explain.
+
+
+def test_a_route_whose_target_is_gone_aborts_without_touching_a_source(temp_db):
+    config = _config()
+    config.pbss = []  # the target device deleted out from under the route
+    deps, alpha, _beta, _pbs = _deps()
+
+    run_id = _run(config, deps)
+    status, steps = _load(run_id)
+
+    assert status == RunStatus.ABORTED
+    assert steps == {}  # not even a backup step was opened
+    assert alpha.vzdump_calls == []
+    with session_scope() as session:
+        assert session.get(Run, run_id).error_key == "target_pbs_missing"
+
+
+def test_a_source_whose_pve_is_gone_fails_that_source_only(temp_db):
+    config = _config()
+    config.pves = [p for p in config.pves if p.id != "pve-alpha"]
+    deps, alpha, beta, _pbs = _deps()
+
+    run_id = _run(config, deps)
+    status, steps = _load(run_id)
+
+    # The missing source fails; pve-beta still gets its backup, which is the whole point
+    # of isolating sources from each other.
+    assert status == RunStatus.FAILURE
+    assert steps["backup:pve-beta"] == "success"
+    assert alpha.vzdump_calls == []
+    assert len(beta.vzdump_calls) == 1
+    assert any("source_pve_missing" in m or "pve-alpha" in m for m in _logs(run_id, LogLevel.ERROR))
+
+
+def test_a_source_with_no_storage_for_the_target_fails_that_source(temp_db):
+    config = _config()
+    config.pves[0].storages = {}  # pve-alpha can no longer reach the target
+    deps, alpha, beta, _pbs = _deps()
+
+    run_id = _run(config, deps)
+    status, steps = _load(run_id)
+
+    assert status == RunStatus.FAILURE
+    assert steps["backup:pve-alpha"] == "failure"
+    assert alpha.vzdump_calls == []
+    assert len(beta.vzdump_calls) == 1
+
+
 # --- caches -------------------------------------------------------------------
 
 
@@ -415,6 +493,59 @@ def test_cancel_before_the_first_source_starts_nothing(temp_db):
     assert status == RunStatus.ABORTED
     assert alpha.vzdump_calls == []
     assert steps == {}
+
+
+def test_cancel_between_sources_leaves_the_rest_unstarted(temp_db):
+    # The gap the task waits cannot cover: a stop that lands after one source finished and
+    # before the next begins.
+    config = _config()
+    alpha = FakePve(guests=list(ALPHA_GUESTS))
+    beta = FakePve(guests=list(BETA_GUESTS))
+    deps, *_ = _deps(alpha=alpha, beta=beta, cancelled=lambda: bool(alpha.vzdump_calls))
+
+    status, steps = _load(_run(config, deps))
+
+    assert status == RunStatus.ABORTED
+    assert alpha.vzdump_calls != []  # the first source did run
+    assert beta.vzdump_calls == []  # the second never started
+    assert "backup:pve-beta" not in steps
+
+
+def test_cancel_after_the_sources_skips_gc(temp_db):
+    # Stopping a run must not leave GC churning on a box the user just asked to release.
+    config = _config()
+    config.routes[0].options.gc = True
+    alpha = FakePve(guests=list(ALPHA_GUESTS))
+    beta = FakePve(guests=list(BETA_GUESTS))
+    pbs = FakePbs()
+    # Cancelled the moment both sources have run, which is exactly the gap before GC.
+    deps, *_ = _deps(
+        alpha=alpha, beta=beta, pbs=pbs,
+        cancelled=lambda: bool(alpha.vzdump_calls) and bool(beta.vzdump_calls),
+    )
+
+    status, steps = _load(_run(config, deps))
+
+    assert status == RunStatus.ABORTED
+    assert pbs.gc_started is False
+    assert "gc" not in steps
+
+
+def test_cancel_after_gc_skips_verify(temp_db):
+    config = _config()
+    config.routes[0].options.gc = True
+    config.routes[0].options.verify_after = True
+    alpha = FakePve(guests=list(ALPHA_GUESTS))
+    beta = FakePve(guests=list(BETA_GUESTS))
+    pbs = FakePbs()
+    deps, *_ = _deps(alpha=alpha, beta=beta, pbs=pbs, cancelled=lambda: pbs.gc_started)
+
+    status, steps = _load(_run(config, deps))
+
+    assert status == RunStatus.ABORTED
+    assert pbs.gc_started is True  # GC did run
+    assert pbs.verify_started is False  # verify did not
+    assert "verify" not in steps
 
 
 # --- end to end through the queue (the lease owns the power) ------------------

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -11,7 +11,9 @@ from conftest import with_devices
 from app.config import Config
 from app.core.scheduler import (
     HEARTBEAT_JOB_ID,
+    PRUNE_HOUR,
     PRUNE_JOB_ID,
+    PRUNE_MINUTE,
     Scheduler,
     _build_trigger,
     _translate_dow,
@@ -381,3 +383,18 @@ def test_the_heartbeat_survives_the_kill_switch():
     sched.arm_heartbeat()
     sched.rearm(_config(scheduler_enabled=False))
     assert sched._scheduler.get_job(HEARTBEAT_JOB_ID) is not None
+
+
+def test_the_prune_job_fires_at_the_documented_time():
+    """03:30 daily, and the only thing that said so was a log line.
+
+    Moving it would silently change when history is deleted, in the middle of the window
+    a nightly backup is most likely to still be running.
+    """
+    sched = Scheduler(lambda _id, _t: None, run_prune=lambda: None, timezone="UTC")
+    sched.arm_prune()
+
+    trigger = str(sched.prune_job.trigger)
+    assert f"hour='{PRUNE_HOUR}'" in trigger
+    assert f"minute='{PRUNE_MINUTE}'" in trigger
+    assert (PRUNE_HOUR, PRUNE_MINUTE) == (3, 30)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react-i18next": "^17.0.11"
       },
       "devDependencies": {
+        "@types/node": "^26.2.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.0.5",
@@ -435,6 +436,16 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.18",
@@ -1390,6 +1401,13 @@
         "@typescript/typescript-win32-arm64": "7.0.2",
         "@typescript/typescript-win32-x64": "7.0.2"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
-    "build:demo": "tsc --noEmit && vite build --mode demo --base ./ --outDir dist-demo",
+    "build": "npm run typecheck && vite build",
+    "build:demo": "npm run typecheck && vite build --mode demo --base ./ --outDir dist-demo",
     "preview": "vite preview",
-    "test": "node --test"
+    "test": "node --test",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json"
   },
   "dependencies": {
     "@codemirror/commands": "^6.10.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-i18next": "^17.0.11"
   },
   "devDependencies": {
+    "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -210,3 +210,65 @@ test('a 204 resolves to nothing instead of failing to parse an empty body', asyn
     restore()
   }
 })
+
+test('a successful GET returns the parsed body', async () => {
+  // Guards the 204 branch from the other side: treating every response as empty would
+  // hand every caller undefined and blank the whole dashboard.
+  const { restore } = recordFetch(jsonResponse(200, { scheduler_enabled: false }))
+  try {
+    assert.deepEqual(await api.status(), { scheduler_enabled: false })
+  } finally {
+    restore()
+  }
+})
+
+test('an abort that is not our timeout is not disguised as a 408', async () => {
+  // Only our own backstop produces 408. A different DOMException has to reach the caller
+  // as itself, or a real browser error would be reported as "the request timed out".
+  const orig = globalThis.fetch
+  globalThis.fetch = (async () => {
+    throw new DOMException('network changed', 'NetworkError')
+  }) as typeof fetch
+  try {
+    await assert.rejects(
+      () => api.status(),
+      (e: unknown) => e instanceof DOMException && e.name === 'NetworkError',
+    )
+  } finally {
+    globalThis.fetch = orig
+  }
+})
+
+test('an error body with no detail keeps the status text', async () => {
+  // `j && typeof j.detail !== 'undefined'`: without the second half, the message becomes
+  // the string "undefined" instead of something the user can read.
+  const { restore } = recordFetch(
+    new Response(JSON.stringify({ error: 'nope' }), {
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  )
+  try {
+    await assert.rejects(
+      () => api.status(),
+      (e: unknown) => e instanceof ApiError && e.message === 'Internal Server Error',
+    )
+  } finally {
+    restore()
+  }
+})
+
+test('an omitted password is sent as null, not dropped from the body', async () => {
+  // The backend reads null/"" as "keep the current password"; a missing key would be a
+  // different request shape and the account form would stop being able to say "unchanged".
+  const { calls, restore } = recordFetch(jsonResponse(200, { username: 'admin' }))
+  try {
+    await api.updateAccount('current-pw', 'admin')
+    const body = JSON.parse(calls[0].body as string)
+    assert.ok('password' in body)
+    assert.equal(body.password, null)
+  } finally {
+    restore()
+  }
+})

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -81,3 +81,132 @@ test('the backstop timeout aborts a hung request and surfaces a 408 ApiError (FE
   mock.timers.reset()
   setTimeoutMessage('The request timed out.')
 })
+
+// --- what actually goes on the wire, and what comes back ---------------------
+//
+// The stub above ignores the URL, so nothing proved a method calls the right endpoint,
+// carries a JSON body, or decodes the backend's error shapes. That decoding is how every
+// 422 reaches the UI.
+
+type Recorded = { url: string; method: string; headers: Headers; body?: string }
+
+function recordFetch(response: Response): { calls: Recorded[]; restore: () => void } {
+  const calls: Recorded[] = []
+  const orig = globalThis.fetch
+  globalThis.fetch = (async (url: string, init: RequestInit) => {
+    calls.push({
+      url,
+      method: String(init.method),
+      headers: new Headers(init.headers),
+      body: init.body as string | undefined,
+    })
+    return response.clone()
+  }) as unknown as typeof fetch
+  return { calls, restore: () => { globalThis.fetch = orig } }
+}
+
+const jsonResponse = (status: number, payload: unknown) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+test('a GET carries no body and no content type', async () => {
+  const { calls, restore } = recordFetch(jsonResponse(200, { scheduler_enabled: true }))
+  try {
+    await api.status()
+    assert.equal(calls[0].url, '/api/status')
+    assert.equal(calls[0].method, 'GET')
+    assert.equal(calls[0].body, undefined)
+    assert.equal(calls[0].headers.get('content-type'), null)
+  } finally {
+    restore()
+  }
+})
+
+test('a body is JSON-encoded and announced as JSON', async () => {
+  // Without the header FastAPI reads the body as a form and answers 422 for everything.
+  const { calls, restore } = recordFetch(jsonResponse(200, { username: 'admin' }))
+  try {
+    await api.login('admin', 'secret12')
+    assert.equal(calls[0].url, '/api/login')
+    assert.equal(calls[0].method, 'POST')
+    assert.equal(calls[0].headers.get('content-type'), 'application/json')
+    assert.deepEqual(JSON.parse(calls[0].body as string), {
+      username: 'admin',
+      password: 'secret12',
+    })
+  } finally {
+    restore()
+  }
+})
+
+test('a string detail becomes the error message', async () => {
+  const { restore } = recordFetch(jsonResponse(409, { detail: 'route is already running' }))
+  try {
+    await assert.rejects(
+      () => api.status(),
+      (e: unknown) =>
+        e instanceof ApiError && e.status === 409 && e.message === 'route is already running',
+    )
+  } finally {
+    restore()
+  }
+})
+
+test('a structured detail prefers its message and keeps the raw payload', async () => {
+  // The YAML editor's 422 shape: the modal shows `message` and uses `line` to place the
+  // marker, so both halves have to survive.
+  const detail = { message: 'invalid schedule.cron', line: 12 }
+  const { restore } = recordFetch(jsonResponse(422, { detail }))
+  try {
+    await assert.rejects(
+      () => api.status(),
+      (e: unknown) => {
+        assert.ok(e instanceof ApiError)
+        assert.equal(e.message, 'invalid schedule.cron')
+        assert.deepEqual(e.raw, detail)
+        return true
+      },
+    )
+  } finally {
+    restore()
+  }
+})
+
+test('a structured detail with no message falls back to its JSON', async () => {
+  const detail = [{ loc: ['body', 'host'], msg: 'field required' }]
+  const { restore } = recordFetch(jsonResponse(422, { detail }))
+  try {
+    await assert.rejects(
+      () => api.status(),
+      (e: unknown) => e instanceof ApiError && e.message === JSON.stringify(detail),
+    )
+  } finally {
+    restore()
+  }
+})
+
+test('a non-JSON error body keeps the status text', async () => {
+  const { restore } = recordFetch(
+    new Response('<html>502 Bad Gateway</html>', { status: 502, statusText: 'Bad Gateway' }),
+  )
+  try {
+    await assert.rejects(
+      () => api.status(),
+      (e: unknown) => e instanceof ApiError && e.message === 'Bad Gateway',
+    )
+  } finally {
+    restore()
+  }
+})
+
+test('a 204 resolves to nothing instead of failing to parse an empty body', async () => {
+  // DELETE /config/api-key answers 204; parsing "" as JSON would throw over a success.
+  const { restore } = recordFetch(new Response(null, { status: 204 }))
+  try {
+    assert.equal(await api.logout(), undefined)
+  } finally {
+    restore()
+  }
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -53,7 +53,7 @@
 
 /* Theme palettes. Dark is the default; index.html sets data-theme before first paint from
    localStorage, and ConfigContext keeps it in sync with app.theme. Every color the app uses
-   must exist in BOTH blocks (test/theme-parity.test.js enforces it). */
+   must exist in BOTH blocks (src/theme.test.ts enforces it). */
 :root {
   color-scheme: dark;
   --jn-bg: #0f1216;

--- a/frontend/src/theme.test.ts
+++ b/frontend/src/theme.test.ts
@@ -43,3 +43,113 @@ test('every var(--jn-*) referenced anywhere in src is defined in the palette', (
     }
   }
 })
+
+// --- applyTheme / currentTheme ------------------------------------------------
+//
+// theme.ts was read as text above but never imported, so its two functions had no
+// coverage at all. There is no DOM here, so document and localStorage are stubbed the way
+// clipboard.test.ts stubs its globals.
+
+function stub(name: string, value: unknown): () => void {
+  const original = Object.getOwnPropertyDescriptor(globalThis, name)
+  Object.defineProperty(globalThis, name, { value, configurable: true, writable: true })
+  return () => {
+    if (original) Object.defineProperty(globalThis, name, original)
+    else delete (globalThis as Record<string, unknown>)[name]
+  }
+}
+
+function fakeDom(initial?: string) {
+  const classes = new Set<string>()
+  const meta = { content: '' }
+  const documentElement = {
+    dataset: initial ? { theme: initial } : ({} as Record<string, string>),
+    classList: {
+      add: (c: string) => classes.add(c),
+      remove: (c: string) => classes.delete(c),
+    },
+  }
+  return {
+    documentElement,
+    classes,
+    meta,
+    querySelector: (selector: string) =>
+      selector.includes('theme-color') ? { setAttribute: (_k: string, v: string) => (meta.content = v) } : null,
+  }
+}
+
+test('currentTheme reads the stamped attribute and defaults to dark', async () => {
+  const { currentTheme } = await import('./theme.ts')
+
+  let restore = stub('document', fakeDom('light'))
+  try {
+    assert.equal(currentTheme(), 'light')
+  } finally {
+    restore()
+  }
+
+  restore = stub('document', fakeDom())
+  try {
+    // Nothing stamped means dark: the app is dark-first, and index.html stamps before paint.
+    assert.equal(currentTheme(), 'dark')
+  } finally {
+    restore()
+  }
+})
+
+test('applyTheme stamps the root, updates the tab colour and remembers the choice', async () => {
+  const { applyTheme } = await import('./theme.ts')
+  const dom = fakeDom('dark')
+  const stored: Record<string, string> = {}
+  const restoreDoc = stub('document', dom)
+  const restoreStorage = stub('localStorage', {
+    setItem: (k: string, v: string) => (stored[k] = v),
+  })
+  try {
+    applyTheme('light')
+
+    assert.equal(dom.documentElement.dataset.theme, 'light')
+    // The browser chrome has to follow, or the tab keeps the other theme's colour.
+    assert.equal(dom.meta.content, '#f3f4f6')
+    assert.equal(stored.jnTheme, 'light')
+    assert.ok(dom.classes.has('theme-fade')) // the cross-fade is armed on a real change
+  } finally {
+    restoreDoc()
+    restoreStorage()
+  }
+})
+
+test('applyTheme does not cross-fade when the theme is unchanged', async () => {
+  // Re-applying the current theme (a config reload) should not flash the whole page.
+  const { applyTheme } = await import('./theme.ts')
+  const dom = fakeDom('dark')
+  const restoreDoc = stub('document', dom)
+  const restoreStorage = stub('localStorage', { setItem: () => {} })
+  try {
+    applyTheme('dark')
+    assert.equal(dom.classes.has('theme-fade'), false)
+    assert.equal(dom.documentElement.dataset.theme, 'dark')
+  } finally {
+    restoreDoc()
+    restoreStorage()
+  }
+})
+
+test('applyTheme still applies when storage is unavailable', async () => {
+  // Private browsing throws on setItem; the theme must still change for the session.
+  const { applyTheme } = await import('./theme.ts')
+  const dom = fakeDom('dark')
+  const restoreDoc = stub('document', dom)
+  const restoreStorage = stub('localStorage', {
+    setItem: () => {
+      throw new Error('storage disabled')
+    },
+  })
+  try {
+    applyTheme('light')
+    assert.equal(dom.documentElement.dataset.theme, 'light')
+  } finally {
+    restoreDoc()
+    restoreStorage()
+  }
+})

--- a/frontend/src/theme.test.ts
+++ b/frontend/src/theme.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict'
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import test from 'node:test'
+import { fileURLToPath } from 'node:url'
 
 // The light theme is a second block of --jn-* definitions in index.css. The most likely
 // future regression is adding a token to one palette and forgetting the other, which
@@ -22,20 +24,20 @@ test('both theme palettes exist and define the same token set', () => {
   assert.deepEqual([...dark].sort(), [...light].sort())
 })
 
-test('every var(--jn-*) referenced in code is defined in the palette', () => {
+test('every var(--jn-*) referenced anywhere in src is defined in the palette', () => {
   const dark = varsIn(darkBlock)
-  // The stylesheets are in here too: they are where most `var()` references live, and a
-  // token that exists in neither palette renders as the inherited value rather than failing,
-  // so nothing else would catch it.
-  for (const file of [
-    'theme.ts',
-    'utils/status.ts',
-    'dashboard.css',
-    'settings.css',
-    'wizard.css',
-    'responsive.css',
-  ]) {
-    const src = readFileSync(new URL(`./${file}`, import.meta.url), 'utf8')
+  // Walked, not listed: the hardcoded six-file version missed six real source files that
+  // reference tokens, and a token defined in neither palette renders as the inherited
+  // value rather than failing, so nothing else would catch it.
+  const root = fileURLToPath(new URL('.', import.meta.url))
+  const files = readdirSync(root, { recursive: true, withFileTypes: true })
+    .filter((e) => e.isFile() && /\.(ts|tsx|css)$/.test(e.name) && !/\.test\.tsx?$/.test(e.name))
+    .map((e) => join(e.parentPath, e.name))
+
+  assert.ok(files.length > 20, `expected to walk the whole tree, found ${files.length} files`)
+
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8')
     for (const m of src.matchAll(/var\((--jn-[\w-]+)\)/g)) {
       assert.ok(dark.has(m[1]), `${file} references ${m[1]} which index.css does not define`)
     }

--- a/frontend/src/utils/clipboard.test.ts
+++ b/frontend/src/utils/clipboard.test.ts
@@ -162,3 +162,58 @@ test('no document available: resolves false without throwing', async () => {
     restoreDocument()
   }
 })
+
+// Each condition in the secure-context guard on its own. The suite covered "all four true"
+// and "none true", so any one of them could be dropped and the copy button would either
+// throw on plain HTTP or skip a working Clipboard API.
+
+test('a secure context with no Clipboard API falls back rather than throwing', async () => {
+  const restoreWindow = setGlobal('window', { isSecureContext: true })
+  const restoreNavigator = setGlobal('navigator', {}) // no .clipboard at all
+  const restoreDocument = setGlobal('document', undefined)
+  try {
+    assert.equal(await copyToClipboard('x'), false) // fell through to the textarea path
+  } finally {
+    restoreWindow()
+    restoreNavigator()
+    restoreDocument()
+  }
+})
+
+test('an insecure context never touches navigator.clipboard', async () => {
+  // http://192.168.x.x is how this app is normally reached, and writeText there throws or
+  // silently no-ops, so it must not even be attempted.
+  let attempted = false
+  const restoreWindow = setGlobal('window', { isSecureContext: false })
+  const restoreNavigator = setGlobal('navigator', {
+    clipboard: {
+      writeText: async () => {
+        attempted = true
+      },
+    },
+  })
+  const restoreDocument = setGlobal('document', undefined)
+  try {
+    assert.equal(await copyToClipboard('x'), false)
+    assert.equal(attempted, false)
+  } finally {
+    restoreWindow()
+    restoreNavigator()
+    restoreDocument()
+  }
+})
+
+test('a document with no body yet resolves false instead of throwing', async () => {
+  // appendChild on a null body would throw out of an event handler and take the click
+  // with it; returning false lets the caller show "copy failed".
+  const restoreWindow = setGlobal('window', { isSecureContext: false })
+  const restoreNavigator = setGlobal('navigator', {})
+  const restoreDocument = setGlobal('document', { createElement: () => ({}), body: null })
+  try {
+    assert.equal(await copyToClipboard('x'), false)
+  } finally {
+    restoreWindow()
+    restoreNavigator()
+    restoreDocument()
+  }
+})

--- a/frontend/src/utils/cron.test.ts
+++ b/frontend/src/utils/cron.test.ts
@@ -17,8 +17,25 @@ test('round-trips a weekday subset (Mon,Wed,Fri)', () => {
 })
 
 test('0 and 7 both mean Sunday (our index 6)', () => {
-  assert.equal(parseCron('0 2 * * 0').days[6], true)
-  assert.equal(parseCron('0 2 * * 7').days[6], true)
+  // The whole array, not just index 6: checking one slot cannot tell "Sunday" from
+  // "Sunday and whatever the array happened to start with".
+  const sunday = [false, false, false, false, false, false, true]
+  assert.deepEqual(parseCron('0 2 * * 0').days, sunday)
+  assert.deepEqual(parseCron('0 2 * * 7').days, sunday)
+})
+
+test('a single mid-week day selects that day and nothing else', () => {
+  // cron dow 2 = Tuesday = our index 1.
+  assert.deepEqual(parseCron('0 2 * * 2').days, [
+    false, true, false, false, false, false, false,
+  ])
+  assert.equal(buildCron(parseCron('0 2 * * 2')), '0 2 * * 2')
+})
+
+test('an unparseable day list falls back to every day rather than to none', () => {
+  // A cron nobody can read must not produce a schedule that never fires; daily is the
+  // safe reading, and it is what the UI then shows the user.
+  assert.deepEqual(parseCron('0 2 * * xyz').days, Array(7).fill(true))
 })
 
 test('preserves day-of-month/month through the round-trip (JN-006)', () => {

--- a/frontend/src/utils/deviceForm.test.ts
+++ b/frontend/src/utils/deviceForm.test.ts
@@ -247,3 +247,13 @@ test('deviceSaveErrors pins a 422 on its field and a whole-config error on the b
     { message: 'api_token_secret was sent as ***REDACTED***' },
   ])
 })
+
+test('an unmanaged box that is down reads offline, not always-on', () => {
+  // managedPower defaults to false, so an omitted argument must mean "not ours to wake":
+  // calling a downed box "sleeping" would present a fault as normal behaviour.
+  assert.equal(deviceState(false), 'offline')
+  assert.equal(deviceState(undefined), 'offline')
+  assert.equal(deviceState(false, false), 'offline')
+  assert.equal(deviceState(false, true), 'sleeping')
+  assert.equal(deviceState(true, false), 'connected')
+})

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { fmtBytesTB, fmtDuration, fmtUptime, rel } from './format.ts'
+import { fmtBytesTB, fmtClock, fmtDT, fmtDuration, fmtShort, fmtUptime, rel } from './format.ts'
 
 test('rel: sub-minute vs rounds-to-a-minute', () => {
   assert.equal(rel(0), '<1m')
@@ -41,4 +41,21 @@ test('fmtUptime: compact d/h/m with rollovers', () => {
   assert.equal(fmtUptime(3660), '1h 1m')
   assert.equal(fmtUptime(90_000), '1d 1h')
   assert.equal(fmtUptime(-5), '0m')
+})
+
+test('fmtClock shows seconds by default and drops them on request', () => {
+  // The header clock ticks every second, so the default matters; the compact form is what
+  // the run rows use. Neither was covered.
+  const d = new Date(2026, 7, 19, 4, 5, 9)
+  assert.equal(fmtClock(d), '04:05:09')
+  assert.equal(fmtClock(d, false), '04:05')
+  assert.equal(fmtClock(d, true), '04:05:09')
+})
+
+test('fmtDT and fmtShort pad every field to two digits', () => {
+  // Day/month order is deliberate and locale-independent here; an unpadded field would
+  // make the column ragged and the dates ambiguous.
+  const d = new Date(2026, 7, 3, 4, 5)
+  assert.equal(fmtShort(d), '03/08 04:05')
+  assert.ok(fmtDT(d).endsWith('03/08 04:05'))
 })

--- a/frontend/src/utils/routeForm.test.ts
+++ b/frontend/src/utils/routeForm.test.ts
@@ -523,3 +523,43 @@ test('a cron-pinned route does not need a weekday ticked', () => {
   noCronNoDays.days = Array(7).fill(false)
   assert.ok(keys(noCronNoDays).includes('dashboard.routeModal.errNoDay'))
 })
+
+test('a difference in any single retention field is a conflict', () => {
+  // retentionDiffers is a chain of ors; a broken link means two routes that really will
+  // prune each other's snapshots are reported as compatible, which is the silent
+  // data-loss case this warning exists for.
+  for (const field of ['keep_last', 'keep_daily', 'keep_weekly', 'keep_monthly', 'keep_yearly'] as const) {
+    const other = route('weekly', {
+      name: 'Weekly',
+      retention: { ...DEFAULT_RETENTION, [field]: 42 },
+    })
+    assert.deepEqual(
+      retentionOverlaps(draft({ id: 'nightly' }), [other]),
+      ['Weekly'],
+      `${field} differing should be a conflict`,
+    )
+  }
+})
+
+test('the guest-selection check only applies to backup routes', () => {
+  // Reachable the moment a PBS chip is added to a route that already has PVE sources:
+  // inferKind calls that sync, but pveSources is still non-empty, so without the kind
+  // check the form would refuse to save over guests the route no longer backs up.
+  const mixed = draft({
+    sourceIds: ['pve:pve-alpha', 'pbs:pbs-01'],
+    target: 'pbs-02',
+    guestMode: 'include',
+    selection: { 'pve-alpha': [] },
+  })
+  assert.equal(inferKind(mixed.sourceIds, mixed.onWake), 'sync')
+  assert.ok(!keys(mixed).includes('dashboard.routeModal.errNoGuests'))
+
+  // The same empty selection on a real backup route is still refused.
+  const backup = draft({
+    sourceIds: ['pve:pve-alpha'],
+    target: 'pbs-01',
+    guestMode: 'include',
+    selection: { 'pve-alpha': [] },
+  })
+  assert.ok(keys(backup).includes('dashboard.routeModal.errNoGuests'))
+})

--- a/frontend/src/utils/routeForm.test.ts
+++ b/frontend/src/utils/routeForm.test.ts
@@ -22,8 +22,6 @@ import {
   validateDraft,
 } from './routeForm.ts'
 
-const PBS_IDS = ['pbs-01', 'pbs-02']
-
 const pve = (id: string, storages: Record<string, string> = { 'pbs-01': 'pbs-backup' }): PveDevice => ({
   id,
   host: '10.0.0.1',

--- a/frontend/src/utils/routeForm.test.ts
+++ b/frontend/src/utils/routeForm.test.ts
@@ -429,3 +429,63 @@ test('anything else falls back to the message the client already built', () => {
     { message: 'config.yaml is read-only' },
   ])
 })
+
+// --- the defaults a new route starts from ------------------------------------
+//
+// Asserted whole, because these are what the user gets by opening the modal and pressing
+// Save. Nothing pinned them, so every flag in DEFAULT_OPTIONS and every field of a fresh
+// draft could flip without a single test noticing.
+
+test('a new route runs GC, does not verify, and does not remove vanished snapshots', () => {
+  assert.deepEqual(DEFAULT_OPTIONS, {
+    mode: 'snapshot',
+    bwlimit: 0,
+    min_free_percent: 0, // the free-space preflight is opt-in
+    gc: true, // reclaiming space is the point of an automated backup
+    verify_after: false, // verification is slow; it is a choice, not a default
+    reverify_days: 30,
+    transfer_last: 0,
+    remove_vanished: false, // never delete on the target unless asked
+  })
+})
+
+test('the default retention is a week of dailies tapering to six months', () => {
+  assert.deepEqual(DEFAULT_RETENTION, {
+    keep_last: 0, // no "keep the last N whatever they are": the tiers below decide
+    keep_daily: 7,
+    keep_weekly: 4,
+    keep_monthly: 6,
+    keep_yearly: 0,
+  })
+})
+
+test('a fresh draft is enabled, notifying, and armed every day', () => {
+  const draft = draftFromRoute(null, [pbs('pbs-01'), pbs('pbs-02')])
+
+  assert.equal(draft.enabled, true) // a route you just created should run
+  assert.equal(draft.notify, true) // and tell you when it did
+  assert.deepEqual(draft.days, Array(7).fill(true))
+  assert.equal(draft.time, '04:00')
+  assert.equal(draft.cron, '') // the simple schedule, not the raw escape hatch
+  assert.equal(draft.guestMode, 'all')
+  assert.equal(draft.target, 'pbs-01') // the first backup server, not an empty select
+  assert.deepEqual(draft.options, DEFAULT_OPTIONS)
+})
+
+test('a fresh draft has no target when there is no backup server yet', () => {
+  assert.equal(draftFromRoute(null, []).target, '')
+})
+
+test('a retention change in any single field counts as a change', () => {
+  // The comparison is a chain of ors; with one link broken, editing that one field would
+  // save a route whose retention silently reverted to the stored value.
+  const stored = route('nightly')
+  for (const field of ['keep_last', 'keep_daily', 'keep_weekly', 'keep_monthly', 'keep_yearly'] as const) {
+    const draft = {
+      ...draftFromRoute(stored, [pbs('pbs-01')]),
+      retention: { ...DEFAULT_RETENTION, [field]: 99 },
+    }
+    const saved = draftToRoute(draft, [])
+    assert.equal(saved.retention?.[field], 99, field)
+  }
+})

--- a/frontend/src/utils/routeForm.test.ts
+++ b/frontend/src/utils/routeForm.test.ts
@@ -489,3 +489,37 @@ test('a retention change in any single field counts as a change', () => {
     assert.equal(saved.retention?.[field], 99, field)
   }
 })
+
+test('the sync single-source rule only applies to sync routes', () => {
+  // `kind === 'sync' && length > 1`: with the kind check dropped, a two-PVE backup route
+  // (the normal case) would be refused.
+  const twoPves = draft({ sourceIds: ['pve:pve-alpha', 'pve:pve-beta'], target: 'pbs-01' })
+  assert.ok(!keys(twoPves).includes('dashboard.routeModal.errSyncSingle'))
+})
+
+test('the storage check only applies once a target is chosen', () => {
+  // `kind === 'backup' && draft.target`: without the target check it would report "no
+  // storage for pbs undefined" the moment a source chip is added.
+  const noTarget = draft({ sourceIds: ['pve-lab'], target: '' })
+  assert.ok(!keys(noTarget).includes('dashboard.routeModal.errNoStorage'))
+})
+
+test('an external route onto a managed box is accepted', () => {
+  // `target && !target.managed_power`: with the flag check dropped, every external route
+  // would be refused, including the ones that are the whole point of the kind.
+  const managed = draft({ sourceIds: [], onWake: 'external', target: 'pbs-01' })
+  assert.ok(!keys(managed).includes('dashboard.routeModal.errExternalUnmanaged'))
+})
+
+test('a cron-pinned route does not need a weekday ticked', () => {
+  // `!draft.cron && !days.some(...)`: the raw cron replaces the weekday toggles entirely,
+  // so demanding a day as well would make the advanced schedule unusable.
+  const pinned = draft({ sourceIds: ['pve:pve-alpha'], target: 'pbs-01' })
+  pinned.cron = '0 4 1 * *'
+  pinned.days = Array(7).fill(false)
+  assert.ok(!keys(pinned).includes('dashboard.routeModal.errNoDay'))
+
+  const noCronNoDays = draft({ sourceIds: ['pve:pve-alpha'], target: 'pbs-01' })
+  noCronNoDays.days = Array(7).fill(false)
+  assert.ok(keys(noCronNoDays).includes('dashboard.routeModal.errNoDay'))
+})

--- a/frontend/src/utils/routes.test.ts
+++ b/frontend/src/utils/routes.test.ts
@@ -124,3 +124,11 @@ test('a cron-pinned route shows the cron and suppresses time/days', () => {
   assert.equal(s.time, '')
   assert.equal(s.daysKey, 'dashboard.scheduleCron')
 })
+
+test('a half-built sync route does not report an unpicked source box', () => {
+  // Both halves of the condition matter: kind alone would push an empty id into the
+  // topology wires and the "left powered on" list.
+  assert.deepEqual(routePbss(route({ kind: 'sync', source_pbs: '', target: 'pbs-02' })), [
+    'pbs-02',
+  ])
+})

--- a/frontend/src/utils/status.test.ts
+++ b/frontend/src/utils/status.test.ts
@@ -222,3 +222,17 @@ test('runDurationMs returns null on an unparseable timestamp and never goes nega
     0,
   )
 })
+
+test('the routeless failed pill is shaped like its named twin', () => {
+  // The named branch is deep-equalled above; this one was only checked for its label, so
+  // `busy` was free to drift and spin the header on a run that is long over.
+  const adhoc = headerPill(
+    status({ last_run: lastRun({ status: 'failure', route_id: null, route_name: null }) }),
+  )
+  assert.deepEqual(adhoc, {
+    labelKey: 'status.lastRunFailedRun',
+    tone: 'red',
+    busy: false,
+    failedAt: '2026-08-08T00:30:00Z',
+  })
+})

--- a/frontend/src/utils/upcoming.test.ts
+++ b/frontend/src/utils/upcoming.test.ts
@@ -107,6 +107,21 @@ const NEXT = [
   { route_id: 'nightly', route_name: 'Nightly', at: local(2026, 8, 4, 2, 0).toISOString() },
 ]
 
+test('only the running row is marked as now', () => {
+  // `now` is what renders the pulsing dot, so a scheduled row inheriting it would show a
+  // future firing as if it were happening.
+  const rows = upcomingRows({
+    running: { routeId: 'nightly', routeName: 'Nightly' },
+    nextRuns: NEXT,
+    routes: [nightly, lab],
+    capacity: 5,
+  })
+
+  assert.equal(rows.filter((r) => r.now).length, 1)
+  assert.equal(rows[0].now, true)
+  assert.ok(rows.slice(1).every((r) => r.now === false))
+})
+
 test('the running row comes first and carries no timestamp', () => {
   const rows = upcomingRows({
     running: { routeId: 'nightly', routeName: 'Nightly' },

--- a/frontend/src/utils/upcoming.test.ts
+++ b/frontend/src/utils/upcoming.test.ts
@@ -72,6 +72,28 @@ test('a malformed time yields nothing instead of Invalid Date rows', () => {
   assert.deepEqual(nextOccurrences(sched({ time: 'nope' }), local(2026, 8, 3), 3), [])
 })
 
+test('half a malformed time is still malformed', () => {
+  // Either field alone being unparseable has to stop it: an hour with a junk minute would
+  // otherwise render an Invalid Date row on the dashboard.
+  assert.deepEqual(nextOccurrences(sched({ time: '04:xx' }), local(2026, 8, 3), 3), [])
+  assert.deepEqual(nextOccurrences(sched({ time: 'xx:30' }), local(2026, 8, 3), 3), [])
+})
+
+test('asking for no occurrences returns none, and asking for one returns one', () => {
+  // `count <= 0` is the guard: with a strict `<`, a zero-length panel would still scan
+  // seven days per requested row and hand back a firing nobody asked for.
+  assert.deepEqual(nextOccurrences(sched({}), local(2026, 8, 3), 0), [])
+  assert.deepEqual(nextOccurrences(sched({}), local(2026, 8, 3), -1), [])
+  assert.equal(nextOccurrences(sched({}), local(2026, 8, 3), 1).length, 1)
+})
+
+test('a schedule with every day switched off never fires', () => {
+  assert.deepEqual(
+    nextOccurrences(sched({ days: Array(7).fill(false) }), local(2026, 8, 3), 3),
+    [],
+  )
+})
+
 // --- upcomingRows ------------------------------------------------------------
 
 const nightly = route('nightly', { color: '#e8830f' })

--- a/frontend/src/utils/wizardFlow.test.ts
+++ b/frontend/src/utils/wizardFlow.test.ts
@@ -411,3 +411,14 @@ test('the port bounds are refused at both ends', () => {
   assert.ok(!keys(1).includes('settings.devices.errPort'))
   assert.ok(!keys(65535).includes('settings.devices.errPort'))
 })
+
+test('an emptied SSH user falls back to root rather than to nothing', () => {
+  // `draft.sshUser.trim() || 'root'`: an empty ssh_user reaches the backend as a device
+  // that can never be powered off, and the failure only shows up at the end of a backup.
+  const device = pbsDeviceFrom(
+    { ...freshPbsDraft([]), host: 'pbs.lan', datastore: 'backup', mac: '00:11:22:33:44:55', sshUser: '   ' },
+    { id: 'root@pam!joulenap-backup', secret: 'sec' },
+  )
+
+  assert.equal(device.ssh_user, 'root')
+})

--- a/frontend/src/utils/wizardFlow.test.ts
+++ b/frontend/src/utils/wizardFlow.test.ts
@@ -343,3 +343,71 @@ test('nothing to warn about when no one else uses that host', () => {
   const victims = tokenConflictVictims('192.0.2.50', [], { pve: [] })
   assert.deepEqual(victims, { devices: [], storages: [] })
 })
+
+// --- the defaults the wizard starts a device from ----------------------------
+//
+// These are what a user gets by clicking through with nothing typed, so each one is a
+// decision. verify_tls in particular is the frontend twin of the backend default: it is
+// what actually lands in config.yaml, and nothing asserted it.
+
+test('a new Proxmox host starts on the PVE port in root mode', () => {
+  const draft = freshPveDraft([])
+
+  assert.equal(draft.port, 8006) // PVE, not the PBS 8007
+  assert.equal(draft.cred, 'root') // quick setup: mint a scoped token from a root password
+  assert.equal(draft.user, 'root@pam')
+  assert.equal(draft.host, '') // nothing pre-filled that could be saved unread
+})
+
+test('a new backup server starts managed, on the PBS port, installing its own key', () => {
+  const draft = freshPbsDraft([])
+
+  assert.equal(draft.port, 8007)
+  // managedPower on is what makes this a power-saving tool rather than a backup scheduler.
+  assert.equal(draft.managedPower, true)
+  assert.equal(draft.autoInstall, true) // offer to install the SSH key, since we generated it
+  assert.equal(draft.sshUser, 'root')
+  assert.equal(draft.cred, 'root')
+})
+
+test('the saved Proxmox device does not verify TLS', () => {
+  // Homelab certificates are self-signed. This is the value that reaches config.yaml, so
+  // it belongs in a test even though (especially though) it is the permissive choice.
+  const device = pveDeviceFrom(
+    { ...freshPveDraft([]), host: '192.168.1.10' },
+    { id: 'root@pam!joulenap', secret: 'sec' },
+    {},
+  )
+
+  assert.equal(device.verify_tls, false)
+})
+
+test('token mode needs both halves, and either one missing is refused', () => {
+  // `tokenId && tokenSecret`: with the wrong operator, half a credential would be sent to
+  // the backend and come back as a confusing 401 instead of a field error.
+  const withToken = (over: Record<string, string>) => ({
+    ...freshPveDraft([]),
+    host: 'pve.lan',
+    cred: 'token' as const,
+    tokenId: 'root@pam!joulenap',
+    tokenSecret: 'sec',
+    ...over,
+  })
+  const keys = (draft: ReturnType<typeof withToken>) =>
+    validateConnectStep(draft, [], []).map((e) => e.key)
+
+  assert.deepEqual(keys(withToken({})), [])
+  assert.ok(keys(withToken({ tokenId: '' })).includes('wizard.err.tokenRequired'))
+  assert.ok(keys(withToken({ tokenSecret: '' })).includes('wizard.err.tokenRequired'))
+  assert.ok(keys(withToken({ tokenId: '   ' })).includes('wizard.err.tokenRequired'))
+})
+
+test('the port bounds are refused at both ends', () => {
+  const draft = (port: number) => ({ ...freshPveDraft([]), host: 'pve.lan', password: 'pw', port })
+  const keys = (port: number) => validateConnectStep(draft(port), [], []).map((e) => e.key)
+
+  assert.ok(keys(0).includes('settings.devices.errPort'))
+  assert.ok(keys(65536).includes('settings.devices.errPort'))
+  assert.ok(!keys(1).includes('settings.devices.errPort'))
+  assert.ok(!keys(65535).includes('settings.devices.errPort'))
+})

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,8 +15,11 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "types": ["node"]
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  // The tests run under node, not in the browser, so they are checked by tsconfig.test.json
+  // with the node types added. Pulling those in here instead would put node's globals in
+  // scope for app code and change what `fetch`, `RequestInit` and friends mean.
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,8 +15,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["node"]
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,12 @@
+// The tests, type-checked. They were excluded from tsconfig.json and node --test strips
+// types without checking them, so nothing verified that a test still matched the module it
+// imports. Kept as a second config rather than folded into the first because these run
+// under node: they need node's globals, and app code must not have them in scope.
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  "exclude": []
+}


### PR DESCRIPTION
A mutation-tested audit of the suite found that it could stay green while real
behaviour was broken, in two ways that repeated across the codebase: it tested
the seams and not the implementations behind them, and it read values from
`config.example.yaml` rather than from the code that declares them.

Two of those were severe.

**The BE-B1 cron guard could be deleted outright and all 703 tests still passed.**
`check_route_crons` rejects a `schedule.cron` that parses as five fields but that
APScheduler cannot build a trigger from; without it a route saves fine and then
silently never fires. Its rejection branch had never executed, because the two
tests that name it fed `"0 4 * *"`, a four-field string the pydantic model
rejects first, so the 422 they asserted never came from the guard. The guard
itself works: driving the real API with `0 4 * * 8` returns 422 with the guard's
own message. It was purely a blind test.

**Every model default in `config.py` was shadowed by the example file.** The
`temp_config` fixture writes the shipped example and loads it, so the pydantic
defaults behind those values were never under test. `update_check: bool = False`
could be flipped to `True` and `test_disabled_by_default_never_calls_out`, the
test written specifically to prove update checks are off by default, still
passed, because it read the `false` from the file.

## What changed

Test-only, apart from one stale comment, the tsconfig split and the CI workflow.
No product behaviour is touched.

- The cron tests now use a well-formed five-field string only `validate_cron` can
  refuse, with the field-count case kept separate so neither guard can go missing,
  plus the changed-only half of the contract.
- New `test_config_defaults.py` builds the models with no YAML anywhere and pins
  the defaults that decide what the app does unasked, plus a parity test holding
  the example and the model to the same values.
- The request-model defaults that touch hardware: `keep_on` (flipping it leaves
  the backup server awake after every manual run) and the wizard's
  `replace_token` (flipping it replaces an API token on a live backup server
  without the user agreeing). `api/wizard.py` had no effective coverage of any of
  its bodies.
- The implementations behind the injected fakes: the `/proc/net/arp` parser, the
  psutil NIC walk, the four functions `LeaseDeps.default()` wires, and
  `node_status`. `healthcheck.py` and `hashpw.py` were at 0% despite both being
  shipped entry points.
- Notification routing for failed and aborted runs, the SMTP 465 and plain-relay
  branches, the untested `GET /devices/pves/{id}/storages`, the three
  `CycleAbort` paths, the cancellation checks around GC, and a set of boundaries
  that were only ever tested from one side.
- `test_the_idle_check_is_skipped_when_the_wait_is_zero` could not fail the way
  it intended: it proved the skip with an exception, but a failing idle check is
  deliberately swallowed, so both paths powered the box off. It records the call
  now.
- The auth guard enumerates the route table instead of a hand-kept list of 22 of
  the 50 operations, with the public ones named and justified.
- The frontend tests were excluded from `tsc` and `@types/node` was never
  installed, so nothing verified that a test still matched the module it imports.
  They are type-checked now, in a second config so node's globals stay out of
  browser code.
- `theme.test.ts` claimed to check every `var(--jn-*)` in the codebase but read a
  hardcoded list of six files, missing six real sources; it walks `src/` now.
- The forty surviving frontend mutants: unasserted default objects, guard
  branches only covered at their extremes, and `api/client.ts`, whose fetch stub
  ignored the URL so nothing proved a method called the right endpoint.

## Verification

The 35 mutants that survived the audit were reapplied one at a time against the
whole suite: 33 now fail it. The two left are unobservable, checked rather than
assumed: in the crash-path branch of `_release_all` the `multi` flag is computed
and then skipped over, and the `left_on` list it builds is discarded by the only
caller that reaches it.

Removing `check_route_crons` from both call sites now fails three tests.

| | before | after |
|---|---|---|
| backend tests | 703 | 800 |
| frontend tests | 192 | 238 |
| backend coverage | 94% | 96% |
| backend mutation score | 73% | 78% |
| frontend mutation score, tested modules | 82% | 97% |

Determinism is unchanged: every backend test file passes standalone, the suite
passes in reverse file order, and three full runs under ten-way parallel load are
green.

## CI

Coverage was measured and uploaded but never enforced, so it could slide back
without failing anything. There is a gate at 94 now, below the current 96 to
leave room for a legitimate dip. Python 3.14 joins the matrix: it is what
development runs on, which made it the version most likely to hit a problem first
and the one nobody checked.

No version bump: nothing user-facing changes.
