### PR TITLE
fix(net): complete the TLS handshake in the reachability probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- The reachability probe that tells an awake PBS from a sleeping one now completes the TLS
+  handshake instead of opening a connection and closing it without speaking. The old probe
+  made `proxmox-backup-proxy` write `failed to check for TLS handshake` and
+  `Failed to get api service` to the PBS syslog on every poll, roughly every 8 seconds while
+  a dashboard was open (#44).
+
 ## [1.1.1]
 
 ### Fixed

--- a/backend/app/connectors/net.py
+++ b/backend/app/connectors/net.py
@@ -1,5 +1,5 @@
-"""Network helpers: TCP reachability (waiting for PBS after WoL) and local interface
-enumeration + Wake-on-LAN target resolution."""
+"""Network helpers: reachability probing (waiting for PBS after WoL) and local
+interface enumeration + Wake-on-LAN target resolution."""
 
 from __future__ import annotations
 
@@ -12,18 +12,26 @@ from dataclasses import dataclass
 
 import psutil
 
+from .errors import ApiError
+from .tls import fetch_peer_der
+
 log = logging.getLogger("joulenap.net")
 
 _GLOBAL_BROADCAST = "255.255.255.255"
 
 
 def tcp_reachable(host: str, port: int, timeout: float = 3.0) -> bool:
-    """True if a TCP connection to ``host:port`` succeeds within ``timeout`` seconds."""
+    """True if ``host:port`` completes a TLS handshake within ``timeout`` seconds.
+
+    Connecting and closing without speaking makes proxmox-backup-proxy log a failed
+    handshake on every poll (issue #44). The cert is read and dropped: only reaching
+    the handshake matters. Every caller targets a PVE or PBS API port, all TLS.
+    """
     try:
-        with socket.create_connection((host, port), timeout=timeout):
-            return True
-    except OSError:
+        fetch_peer_der(host, port, timeout)
+    except ApiError:
         return False
+    return True
 
 
 def wait_until_reachable(

--- a/backend/tests/test_discovery.py
+++ b/backend/tests/test_discovery.py
@@ -52,9 +52,9 @@ def test_detect_mac_primes_arp_with_a_real_connect():
     ``python:3.12-slim`` image — the failure was swallowed, so the cache was never
     populated and the lookup only ever succeeded on traffic somebody else had made.
     """
-    with mock.patch("app.connectors.net.socket.create_connection") as connect:
+    with mock.patch("app.connectors.net.fetch_peer_der") as connect:
         discovery._prime_arp("10.0.0.5", 8007)
-    assert connect.call_args.args[0] == ("10.0.0.5", 8007)
+    assert connect.call_args.args[:2] == ("10.0.0.5", 8007)
 
 
 def test_detect_mac_primes_even_when_the_port_refuses():

--- a/backend/tests/test_net.py
+++ b/backend/tests/test_net.py
@@ -1,21 +1,22 @@
-"""TCP reachability helpers — socket mocked — plus interface/WoL-target resolution."""
+"""Reachability helpers (the TLS probe mocked) plus interface/WoL-target resolution."""
 
 from __future__ import annotations
 
 from unittest import mock
 
 from app.connectors import net
+from app.connectors.errors import ApiError
 from app.connectors.net import NetInterface, tcp_reachable, wait_until_reachable
 
 
 def test_tcp_reachable_true():
-    with mock.patch("socket.create_connection") as cc:
-        cc.return_value.__enter__.return_value = mock.MagicMock()
+    with mock.patch("app.connectors.net.fetch_peer_der") as probe:
         assert tcp_reachable("10.0.0.12", 8007) is True
+    assert probe.called
 
 
 def test_tcp_reachable_false_on_oserror():
-    with mock.patch("socket.create_connection", side_effect=OSError("refused")):
+    with mock.patch("app.connectors.net.fetch_peer_der", side_effect=ApiError("refused")):
         assert tcp_reachable("10.0.0.12", 8007) is False
 
 
@@ -25,13 +26,11 @@ def test_wait_until_reachable_succeeds_after_retries():
     def flaky(*_a, **_k):
         calls["n"] += 1
         if calls["n"] < 3:
-            raise OSError("not yet")
+            raise ApiError("not yet")
         return mock.MagicMock()
 
-    with mock.patch("socket.create_connection", side_effect=flaky):
-        ok = wait_until_reachable(
-            "10.0.0.12", 8007, timeout=10, interval=0, sleep=lambda _s: None
-        )
+    with mock.patch("app.connectors.net.fetch_peer_der", side_effect=flaky):
+        ok = wait_until_reachable("10.0.0.12", 8007, timeout=10, interval=0, sleep=lambda _s: None)
     assert ok is True
     assert calls["n"] == 3
 
@@ -39,7 +38,7 @@ def test_wait_until_reachable_succeeds_after_retries():
 def test_wait_until_reachable_gives_up_immediately_when_cancelled():
     # A cancelled run must not sit through the full wake timeout (11.2). Reported as False,
     # same as a timeout, because "the PBS isn't up" is the state the caller has to handle.
-    with mock.patch("socket.create_connection", side_effect=OSError("down")) as sock:
+    with mock.patch("app.connectors.net.fetch_peer_der", side_effect=ApiError("down")) as sock:
         ok = wait_until_reachable(
             "10.0.0.12",
             8007,
@@ -49,14 +48,12 @@ def test_wait_until_reachable_gives_up_immediately_when_cancelled():
             should_cancel=lambda: True,
         )
     assert ok is False
-    assert sock.call_count == 0  # bailed before even trying to connect
+    assert sock.call_count == 0  # bailed before even trying to reach the host
 
 
 def test_wait_until_reachable_times_out():
-    with mock.patch("socket.create_connection", side_effect=OSError("down")):
-        ok = wait_until_reachable(
-            "10.0.0.12", 8007, timeout=0, interval=0, sleep=lambda _s: None
-        )
+    with mock.patch("app.connectors.net.fetch_peer_der", side_effect=ApiError("down")):
+        ok = wait_until_reachable("10.0.0.12", 8007, timeout=0, interval=0, sleep=lambda _s: None)
     assert ok is False
 
 


### PR DESCRIPTION
The probe that tells an awake backup server from a sleeping one opened a
TCP connection and closed it without sending a byte. proxmox-backup-proxy
peeks at the first bytes of every connection to tell TLS from plain HTTP,
so a client that never speaks makes it log two errors:

    failed to check for TLS handshake: couldn't peek into incoming TCP stream
    Failed to get api service: Transport endpoint is not connected (os error 107)

With a dashboard open that is one pair every 8 seconds, which floods the
PBS syslog for as long as the page stays open.

The probe now finishes the handshake and throws the certificate away,
reusing the helper that already reads a server's fingerprint during setup.
What it reports is unchanged: reachable or not. Every caller targets a PVE
or PBS API port, so speaking TLS is always the right thing to do.

Verified against a live PBS 4.2.3: the syslog stays clean, and waking,
powering off and reading both states still work.

Closes #44
