### PR TITLE
fix(net): make the reachability probe complete a request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Joulenap version
       description: Shown in the UI footer.
-      placeholder: "1.1.2"
+      placeholder: "1.1.3"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.3]
+
+### Fixed
+
+- The reachability probe now makes a real request instead of shaking hands and hanging up.
+  `proxmox-backup-proxy` prepares each connection, peer address and all, in the moment right
+  after the handshake, and a client that disappears exactly then left
+  `Failed to get api service: Transport endpoint is not connected` in the PBS syslog on every
+  poll. Second half of the log-spam fix started in 1.1.2 (#44).
+
 ## [1.1.2]
 
 ### Fixed
@@ -644,7 +654,8 @@ Backup Server, all from a web UI.
 - Config-driven via `config.yaml` (pydantic-validated); secrets stay in `config.yaml` and are
   redacted from API responses.
 
-[Unreleased]: https://github.com/Joulenap/joulenap/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/Joulenap/joulenap/compare/v1.1.3...HEAD
+[1.1.3]: https://github.com/Joulenap/joulenap/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/Joulenap/joulenap/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/Joulenap/joulenap/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/Joulenap/joulenap/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Joulenap **owns the schedule** itself (internal scheduler), so nothing on the Pr
 
 ## Status
 
-**v1.1.2.** Built around routes over any number of PVE and PBS devices: backup, PBS→PBS sync,
+**v1.1.3.** Built around routes over any number of PVE and PBS devices: backup, PBS→PBS sync,
 external-schedule watching and verification, driven by a run queue and a per-server power lease
 so a box is woken once and slept once no matter how many routes need it. Packaged as a Docker
 image, with transport hardening (per-device PBS TLS pinning + SSH host-key verification) and auth

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 """Joulenap — web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."""
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/backend/app/connectors/tls.py
+++ b/backend/app/connectors/tls.py
@@ -27,13 +27,34 @@ def fetch_peer_der(host: str, port: int, timeout: float = 5.0) -> bytes:
     context.verify_mode = ssl.CERT_NONE
     try:
         with socket.create_connection((host, port), timeout=timeout) as sock:
-            with context.wrap_socket(sock, server_hostname=host) as tls_sock:
+            tls_sock = context.wrap_socket(sock, server_hostname=host)
+            try:
                 der = tls_sock.getpeercert(binary_form=True)
+                _say_hello(tls_sock, host)
+            finally:
+                tls_sock.close()
     except OSError as exc:
         raise ApiError(f"Could not read TLS certificate from {host}:{port}: {exc}") from exc
     if not der:
         raise ApiError(f"No TLS certificate presented by {host}:{port}")
     return der
+
+
+def _say_hello(tls_sock: ssl.SSLSocket, host: str) -> None:
+    """Ask for the login page and wait for the answer, so the server sees a visitor.
+
+    proxmox-backup-proxy builds the API service for a connection, peer address and all, in
+    the moment right after the handshake. A client that hangs up in that same moment makes
+    it log a failed poll, once per dashboard refresh (#44). One round trip is enough to be
+    somebody. ``GET /`` needs no credentials, while ``/api2/json/version`` would answer 401
+    and log two lines of its own.
+    """
+    try:
+        tls_sock.sendall(f"GET / HTTP/1.0\r\nHost: {host}\r\n\r\n".encode())
+        while tls_sock.recv(8192):  # read the answer out, or the close resets the connection
+            pass
+    except OSError:
+        pass  # the certificate is what we came for, and the handshake already proved it is up
 
 
 def fingerprint_hex(der: bytes) -> str:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "joulenap"
-version = "1.1.2"
+version = "1.1.3"
 description = "Self-hosted web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."
 requires-python = ">=3.12"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/tests/test_pbs.py
+++ b/backend/tests/test_pbs.py
@@ -358,14 +358,17 @@ def test_get_fingerprint(monkeypatch):
     expected = ":".join(expected[i : i + 2] for i in range(0, len(expected), 2))
 
     class FakeTLS:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *a):
-            return False
-
         def getpeercert(self, binary_form=False):
             return der
+
+        def sendall(self, data):  # the GET / (#44)
+            pass
+
+        def recv(self, n):
+            return b""
+
+        def close(self):
+            pass
 
     class FakeSock:
         def __enter__(self):
@@ -373,6 +376,9 @@ def test_get_fingerprint(monkeypatch):
 
         def __exit__(self, *a):
             return False
+
+        def close(self):
+            pass
 
     monkeypatch.setattr("socket.create_connection", lambda *a, **k: FakeSock())
     monkeypatch.setattr(

--- a/backend/tests/test_tls.py
+++ b/backend/tests/test_tls.py
@@ -1,4 +1,5 @@
 import ssl
+from unittest import mock
 
 import pytest
 
@@ -49,3 +50,24 @@ def test_pinned_context_raises_on_mismatch():
     der = _self_signed_der()
     with pytest.raises(ApiError, match="fingerprint changed"):
         tls.pinned_ssl_context("pbs", 8007, "AA:BB:CC", fetch_der=lambda h, p: der)
+
+
+def test_fetch_peer_der_speaks_before_it_leaves(monkeypatch):
+    """A connection that only shakes hands and vanishes makes PBS log a failed poll (#44),
+    so the probe asks for the login page and reads the answer out before closing."""
+    tls_sock = mock.MagicMock()
+    tls_sock.getpeercert.return_value = b"DER"
+    tls_sock.recv.side_effect = [b"HTTP/1.0 200 OK", b""]
+    ctx = mock.MagicMock(**{"wrap_socket.return_value": tls_sock})
+    monkeypatch.setattr(tls.ssl, "create_default_context", lambda *a, **k: ctx)
+    monkeypatch.setattr(tls.socket, "create_connection", mock.MagicMock())
+
+    assert tls.fetch_peer_der("pbs", 8007) == b"DER"
+    assert tls_sock.sendall.call_args.args[0].startswith(b"GET / HTTP/1.0")
+    tls_sock.close.assert_called_once_with()
+
+    # A server that won't talk must not fail the read, nor leak the socket.
+    tls_sock.reset_mock()
+    tls_sock.sendall.side_effect = OSError("peer gone")
+    assert tls.fetch_peer_der("pbs", 8007) == b"DER"
+    tls_sock.close.assert_called_once_with()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joulenap-frontend",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joulenap-frontend",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@codemirror/commands": "^6.11.0",
         "@codemirror/lang-yaml": "^6.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joulenap-frontend",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/devStub.ts
+++ b/frontend/src/devStub.ts
@@ -822,11 +822,11 @@ function demoRoute(key: string, search: URLSearchParams, init?: RequestInit): un
     // The stub's "-stub" marker and its pending-update badge are dev affordances; a public
     // demo should look like a current, healthy install.
     case 'GET /health':
-      return { status: 'ok', version: '1.1.2' }
+      return { status: 'ok', version: '1.1.3' }
     case 'GET /update':
       return {
-        current: '1.1.2',
-        latest: '1.1.2',
+        current: '1.1.3',
+        latest: '1.1.3',
         update_available: false,
         url: 'https://github.com/Joulenap/joulenap/releases',
       }
@@ -1081,10 +1081,10 @@ const WIZARD_WOL_TEST: { sent: boolean; mac: string; broadcast: string } = {
 }
 
 const ROUTES: Record<string, unknown> = {
-  'GET /health': { status: 'ok', version: '1.1.2-stub' },
+  'GET /health': { status: 'ok', version: '1.1.3-stub' },
   'GET /update': {
-    current: '1.1.2-stub',
-    latest: '1.1.2',
+    current: '1.1.3-stub',
+    latest: '1.1.3',
     update_available: true,
     url: 'https://github.com/Joulenap/joulenap/releases',
   },


### PR DESCRIPTION
Since 1.1.2 the probe finishes the TLS handshake, which silenced one of the two
errors PBS was logging but not the other:

    Failed to get api service: Transport endpoint is not connected (os error 107)

proxmox-backup-proxy prepares each connection, peer address included, in the
moment right after the handshake. A client that shakes hands and leaves in that
same moment is already gone when the proxy looks, so the failure is logged once
per poll, which with a dashboard open is every five seconds.

The probe now sends "GET /" and reads the answer to the end before closing. One
round trip is enough for the connection to be a real client. "GET /" is the login
page, so no credentials are needed and the setup wizard can keep using the same
helper before any token exists. /api2/json/version is not an option: without
credentials it never answers, and it writes an authentication failure and a 401
of its own. Reading the answer to the end matters as well, because leaving part
of it unread makes the close reset the connection.

Both connections a poll opens go through this helper, the reachability probe and
the certificate read behind fingerprint pinning, so both go quiet.

Verified on a live PBS 4.2.5 with a packet capture: twenty probes, forty FINs and
no reset, at 32 ms each. Confirmed on the reporter's PBS 4.2.3, which is where the
symptom was reproducible.

Closes #44
