### PR TITLE
feat(pve): label backups with the guest name in Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Backups triggered by Joulenap now carry the guest name in their Notes, the way a backup job
+  created in the Proxmox VE web interface does. Both the PVE and PBS backup lists show the name
+  next to the ID again, so picking the right snapshot to restore no longer means matching VMIDs
+  by hand.
+
 ## [1.1.3]
 
 ### Fixed

--- a/backend/app/connectors/pve.py
+++ b/backend/app/connectors/pve.py
@@ -162,7 +162,15 @@ class PveClient:
         cluster node to run it on (a backup route starts one task per node); it defaults to
         the client's own node.
         """
-        params: dict[str, Any] = {"storage": storage, "mode": mode}
+        # PVE fills the backup's Notes only when asked to: the GUI's backup-job form defaults
+        # to "{{guestname}}", a bare API call defaults to nothing. Send it ourselves so a
+        # Joulenap-triggered backup is labelled with the guest name in the PVE/PBS lists like
+        # a native job. Available since libpve-guest-common 4.1-2 (PVE 7.3).
+        params: dict[str, Any] = {
+            "storage": storage,
+            "mode": mode,
+            "notes-template": "{{guestname}}",
+        }
         if all_guests:
             params["all"] = 1
         elif vmids:

--- a/backend/tests/test_pve.py
+++ b/backend/tests/test_pve.py
@@ -135,6 +135,7 @@ def test_vzdump_builds_params_and_returns_upid():
     assert body["mode"] == ["snapshot"]
     assert body["prune-backups"] == ["keep-daily=7"]
     assert body["bwlimit"] == ["51200"]
+    assert body["notes-template"] == ["{{guestname}}"]
 
 
 def test_vzdump_all_guests():


### PR DESCRIPTION
PVE fills a backup's Notes only when the caller asks for it: the backup-job
form in the web interface defaults to "{{guestname}}", a bare API call
defaults to nothing. Joulenap called vzdump without it, so every backup it
triggered landed in the PVE and PBS lists with an empty Notes column and only
the VMID to identify it.

Send notes-template="{{guestname}}" with every vzdump, matching what a job
created in the web interface does.

Closes #48