### PR TITLE
fix(pbs): set the owner on a pull sync job

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Joulenap version
       description: Shown in the UI footer.
-      placeholder: "1.2.0"
+      placeholder: "1.2.1"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Joulenap are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1]
+
+### Fixed
+
+- A sync route that pulls now tells PBS who owns the backups it fetches, namely the API token
+  Joulenap uses on the receiving server. Without that field PBS falls back to `root@pam`, and
+  the run fails on every group with "owner check failed" as soon as the target datastore
+  already holds backups owned by the token, which is the normal state of any datastore
+  Joulenap itself backs up to (#51). Push routes were never affected: pushed backups belong to
+  the account named in the remote configuration, whatever the job asks for.
+
+### Changed
+
+- A pull route that ran before this fix wrote its groups on the target as `root@pam`, so the
+  first run afterwards reports the same owner mismatch the other way round. Reassign those
+  groups once on the receiving server, from the datastore's Content tab with Change Owner or
+  with `proxmox-backup-client change-owner`, and the route carries on.
+
 ## [1.2.0]
 
 ### Added
@@ -680,7 +698,8 @@ Backup Server, all from a web UI.
 - Config-driven via `config.yaml` (pydantic-validated); secrets stay in `config.yaml` and are
   redacted from API responses.
 
-[Unreleased]: https://github.com/Joulenap/joulenap/compare/v1.1.3...HEAD
+[Unreleased]: https://github.com/Joulenap/joulenap/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/Joulenap/joulenap/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Joulenap/joulenap/compare/v1.1.3...v1.2.0
 [1.1.3]: https://github.com/Joulenap/joulenap/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/Joulenap/joulenap/compare/v1.1.1...v1.1.2

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Joulenap **owns the schedule** itself (internal scheduler), so nothing on the Pr
 
 ## Status
 
-**v1.2.0.** Built around routes over any number of PVE and PBS devices: backup, PBS→PBS sync,
+**v1.2.1.** Built around routes over any number of PVE and PBS devices: backup, PBS→PBS sync,
 external-schedule watching and verification, driven by a run queue and a per-server power lease
 so a box is woken once and slept once no matter how many routes need it. Packaged as a Docker
 image, with transport hardening (per-device PBS TLS pinning + SSH host-key verification) and auth

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 """Joulenap — web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."""
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/backend/app/connectors/pbs.py
+++ b/backend/app/connectors/pbs.py
@@ -257,6 +257,7 @@ class PbsClient:
         remote_store: str,
         store: str,
         direction: str = "pull",
+        owner: str = "",
         transfer_last: int = 0,
         remove_vanished: bool = False,
     ) -> None:
@@ -267,7 +268,14 @@ class PbsClient:
         ``transfer_last`` > 0 copies only the newest N snapshots per group (PBS wants >= 1, so
         0 means "omit the parameter"); ``remove_vanished`` deletes on the receiving side what
         is gone from the sending side. Both are fields of the shared job schema, accepted for
-        pull and push alike."""
+        pull and push alike.
+
+        ``owner`` is pull-only. On a pull it is the auth-id the fetched groups end up owned by,
+        and PBS defaults it to ``root@pam``: leaving it out makes every run fail with "owner
+        check failed" as soon as the target datastore already holds groups owned by the token
+        Joulenap connects with, which is every datastore Joulenap itself backs up to. On a push
+        the receiving side owns the data as the remote's auth-id whatever the job says, and the
+        field only narrows which local groups may be read, so it is never sent."""
         data: dict[str, Any] = {
             "id": job_id,
             "store": store,
@@ -276,6 +284,8 @@ class PbsClient:
         }
         if direction == "push":
             data["sync-direction"] = "push"
+        elif owner:
+            data["owner"] = owner
         if transfer_last > 0:
             data["transfer-last"] = transfer_last
         if remove_vanished:

--- a/backend/app/jobs/route_cycle.py
+++ b/backend/app/jobs/route_cycle.py
@@ -149,6 +149,7 @@ def _sync_body(
                 remote_store=peer.datastore,
                 store=executor.datastore,
                 direction=route.sync_direction,
+                owner=executor.api_token_id,
                 transfer_last=route.options.transfer_last,
                 remove_vanished=route.options.remove_vanished,
             )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "joulenap"
-version = "1.2.0"
+version = "1.2.1"
 description = "Self-hosted web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."
 requires-python = ">=3.12"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/tests/test_pbs.py
+++ b/backend/tests/test_pbs.py
@@ -125,7 +125,11 @@ def test_pull_sync_job_omits_the_direction():
     handler, calls = _recorder({"sync": []})
 
     make_client(handler).ensure_sync_job(
-        "joulenap-r1", remote="joulenap-r1", remote_store="offsite", store="backup"
+        "joulenap-r1",
+        remote="joulenap-r1",
+        remote_store="offsite",
+        store="backup",
+        owner="root@pam!jn",
     )
 
     body = calls[-1][2]
@@ -133,6 +137,26 @@ def test_pull_sync_job_omits_the_direction():
     # Pull is PBS's default; omitting it keeps the call identical to what servers without
     # push support accept.
     assert "sync-direction" not in body
+    # Without an owner PBS assigns the fetched groups to root@pam, and the sync then fails
+    # per group against groups the token already owns.
+    assert "owner=root%40pam%21jn" in body
+
+
+def test_push_sync_job_never_sends_the_owner():
+    handler, calls = _recorder({"sync": []})
+
+    make_client(handler).ensure_sync_job(
+        "joulenap-r1",
+        remote="joulenap-r1",
+        remote_store="offsite",
+        store="backup",
+        direction="push",
+        owner="root@pam!jn",
+    )
+
+    # Pushed groups are owned by the remote's auth-id whatever the job says; the field would
+    # only narrow which local groups the job may read.
+    assert "owner" not in calls[-1][2]
 
 
 def test_push_sync_job_sends_the_direction_only_in_the_job_body():

--- a/backend/tests/test_route_kinds.py
+++ b/backend/tests/test_route_kinds.py
@@ -125,6 +125,9 @@ def test_pull_sync_runs_the_job_on_the_target(temp_db):
             "remote_store": "offsite",  # the peer's datastore
             "store": "backup",  # the executing side's own
             "direction": "pull",
+            # The executing side's own token, so the pulled groups belong to the identity
+            # that already owns everything on that datastore.
+            "owner": "root@pam!jn1",
             "transfer_last": 0,
             "remove_vanished": False,
         }
@@ -167,6 +170,7 @@ def test_push_sync_runs_the_job_on_the_source(temp_db):
         "remote_store": "backup",
         "store": "offsite",
         "direction": "push",
+        "owner": "root@pam!jn2",  # passed, but a push job never sends it on to PBS
         "transfer_last": 0,
         "remove_vanished": False,
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joulenap-frontend",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joulenap-frontend",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@codemirror/commands": "^6.11.0",
         "@codemirror/lang-yaml": "^6.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joulenap-frontend",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/devStub.ts
+++ b/frontend/src/devStub.ts
@@ -823,11 +823,11 @@ function demoRoute(key: string, search: URLSearchParams, init?: RequestInit): un
     // The stub's "-stub" marker and its pending-update badge are dev affordances; a public
     // demo should look like a current, healthy install.
     case 'GET /health':
-      return { status: 'ok', version: '1.2.0' }
+      return { status: 'ok', version: '1.2.1' }
     case 'GET /update':
       return {
-        current: '1.2.0',
-        latest: '1.2.0',
+        current: '1.2.1',
+        latest: '1.2.1',
         update_available: false,
         url: 'https://github.com/Joulenap/joulenap/releases',
       }
@@ -1082,10 +1082,10 @@ const WIZARD_WOL_TEST: { sent: boolean; mac: string; broadcast: string } = {
 }
 
 const ROUTES: Record<string, unknown> = {
-  'GET /health': { status: 'ok', version: '1.2.0-stub' },
+  'GET /health': { status: 'ok', version: '1.2.1-stub' },
   'GET /update': {
-    current: '1.2.0-stub',
-    latest: '1.2.0',
+    current: '1.2.1-stub',
+    latest: '1.2.1',
     update_available: true,
     url: 'https://github.com/Joulenap/joulenap/releases',
   },


### PR DESCRIPTION
The job is now created with owner set to the API token of the server that runs
it, the target on a pull. Without it PBS defaults to root@pam and the run fails
on every group with "owner check failed" against groups the token already owns.

Push jobs do not send the field: pushed content is owned by the account in the
remote configuration, and there the field only narrows what may be read.

Includes the 1.2.1 version bump and the changelog entry.

Closes #51