### PR TITLE
Release 1.3.1: a vzdump that only warned is a successful backup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Joulenap version
       description: Shown in the UI footer.
-      placeholder: "1.3.0"
+      placeholder: "1.3.1"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Joulenap are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1]
+
+### Fixed
+
+- A backup run is no longer marked failed when `vzdump` finished every guest but warned along
+  the way. Proxmox VE ends such a task with the status `WARNINGS: n` rather than `OK`, and
+  PVE 9 warns on every VM whose EFI disk does not yet carry the 2023 Microsoft certificates,
+  so a route with a couple of UEFI guests was reported as failed, and notified as such, while
+  every backup on the server was fine (#61). Joulenap now treats a warned task as a success,
+  notes the warning count in the run timeline with a pointer to the task log, and still fails
+  the source when a guest was actually lost: `vzdump` reports that as `job errors`, and a
+  guest failure line in the log wins over the warning status either way. PBS sync tasks are
+  unaffected: there `WARNINGS` means groups were not synced, and the run keeps failing.
+
 ## [1.3.0]
 
 ### Added
@@ -743,6 +757,7 @@ Backup Server, all from a web UI.
   redacted from API responses.
 
 [Unreleased]: https://github.com/Joulenap/joulenap/compare/v1.3.0...HEAD
+[1.3.1]: https://github.com/Joulenap/joulenap/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/Joulenap/joulenap/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/Joulenap/joulenap/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Joulenap/joulenap/compare/v1.1.3...v1.2.0

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Joulenap **owns the schedule** itself (internal scheduler), so nothing on the Pr
 
 ## Status
 
-**v1.3.0.** Built around routes over any number of PVE and PBS devices: backup, PBS→PBS sync,
+**v1.3.1.** Built around routes over any number of PVE and PBS devices: backup, PBS→PBS sync,
 external-schedule watching and verification, driven by a run queue and a per-server power lease
 so a box is woken once and slept once no matter how many routes need it. Packaged as a Docker
 image, with transport hardening (per-device PBS TLS pinning + SSH host-key verification) and auth

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,3 +1,3 @@
 """Joulenap — web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/backend/app/jobs/backup_cycle.py
+++ b/backend/app/jobs/backup_cycle.py
@@ -21,7 +21,7 @@ from collections.abc import Callable, Mapping
 from typing import Any, Protocol
 
 from ..config import Config, PbsDevice, PbsExternalConfig, Route, RouteGuests, RouteSource
-from ..connectors.errors import ApiError, TaskCancelled
+from ..connectors.errors import ApiError, TaskCancelled, TaskError
 from ..connectors.pbs import DatastoreStatus
 from ..connectors.pve import Guest, build_prune_string
 from ..db import session_scope
@@ -313,15 +313,28 @@ def _route_backup_source(
             # Counted before the wait: a task that dies still set out to back these up.
             summary.total += len(vmids)
             done_before = summary.ok
-            _wait_or_stop(
-                client,
-                upid,
-                recorder,
-                deps,
-                step_name,
-                "pve",
-                _guest_watcher(summary, names),
-            )
+            failed_before = len(summary.failed)
+            try:
+                _wait_or_stop(
+                    client,
+                    upid,
+                    recorder,
+                    deps,
+                    step_name,
+                    "pve",
+                    _guest_watcher(summary, names),
+                )
+            except TaskError as exc:
+                # vzdump ends with "WARNINGS: n" when every guest finished but some line
+                # warned (PVE 9 EFI certificate notice, #61); a lost guest is "job errors".
+                warned = (exc.exit_status or "").startswith("WARNINGS")
+                if not warned or len(summary.failed) > failed_before:
+                    raise
+                recorder.log(
+                    LogLevel.WARN,
+                    f"vzdump on node '{node}' finished with status '{exc.exit_status}': "
+                    "all guests backed up, see the task log for the warnings",
+                )
             # The task exited OK, so every guest it covered was backed up whatever the log
             # parse made of it — a vzdump wording change must never report "0/14" on a good
             # run. Only on success, so a failed node doesn't advertise guests as backed up.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "joulenap"
-version = "1.3.0"
+version = "1.3.1"
 description = "Self-hosted web UI + scheduler for energy-saving Proxmox backups to a normally-off PBS."
 requires-python = ">=3.12"
 license = { text = "AGPL-3.0-or-later" }

--- a/backend/tests/fakes.py
+++ b/backend/tests/fakes.py
@@ -35,9 +35,11 @@ class FakePve:
         fail_task: bool = False,
         log_lines: list[str] | None = None,
         pbs_storages: list[dict] | None = None,
+        fail_exit_status: str = "job errors",
     ):
         self.guests = guests or []
         self.fail_task = fail_task
+        self.fail_exit_status = fail_exit_status
         self.log_lines = log_lines or []
         # Raw PVE `type=pbs` storage rows, as /storage?type=pbs returns them.
         self.pbs_storages = pbs_storages if pbs_storages is not None else []
@@ -97,7 +99,7 @@ class FakePve:
         if should_cancel is not None and should_cancel():
             raise TaskCancelled(f"Wait for task {upid} cancelled")
         if self.fail_task:
-            raise TaskError("vzdump failed", exit_status="job errors")
+            raise TaskError("vzdump failed", exit_status=self.fail_exit_status)
         return {"status": "stopped", "exitstatus": "OK"}
 
     def stop_task(self, upid: str) -> None:

--- a/backend/tests/test_route_backup.py
+++ b/backend/tests/test_route_backup.py
@@ -281,6 +281,43 @@ def test_a_failing_node_task_fails_only_its_source(temp_db):
     assert steps["gc"] == "success"  # the PBS is awake and the other source's data is real
 
 
+def test_a_vzdump_that_only_warned_is_a_success(temp_db):
+    # PVE 9 ends the task with "WARNINGS: n" when every guest finished but a line warned
+    # (the EFI certificate notice, #61); only "job errors" means a guest was lost.
+    beta = FakePve(
+        guests=list(BETA_GUESTS),
+        fail_task=True,
+        fail_exit_status="WARNINGS: 2",
+        log_lines=[
+            "WARN: EFI disk without 'ms-cert=2023k' option",
+            "INFO: Finished Backup of VM 500",
+        ],
+    )
+    deps, _alpha, _beta, _pbs = _deps(beta=beta)
+    run_id = _run(_config(), deps)
+
+    status, steps = _load(run_id)
+
+    assert status == RunStatus.SUCCESS
+    assert steps["backup:pve-beta"] == "success"
+    assert any("WARNINGS: 2" in line for line in _logs(run_id, LogLevel.WARN))
+
+
+def test_a_warned_vzdump_that_also_lost_a_guest_still_fails(temp_db):
+    beta = FakePve(
+        guests=list(BETA_GUESTS),
+        fail_task=True,
+        fail_exit_status="WARNINGS: 1",
+        log_lines=["ERROR: Backup of VM 500 failed - boom"],
+    )
+    deps, _alpha, _beta, _pbs = _deps(beta=beta)
+
+    status, steps = _load(_run(_config(), deps))
+
+    assert status == RunStatus.FAILURE
+    assert steps["backup:pve-beta"] == "failure"
+
+
 # --- guest tally --------------------------------------------------------------
 
 
@@ -588,7 +625,9 @@ def test_cancel_after_the_sources_skips_gc(temp_db):
     pbs = FakePbs()
     # Cancelled the moment both sources have run, which is exactly the gap before GC.
     deps, *_ = _deps(
-        alpha=alpha, beta=beta, pbs=pbs,
+        alpha=alpha,
+        beta=beta,
+        pbs=pbs,
         cancelled=lambda: bool(alpha.vzdump_calls) and bool(beta.vzdump_calls),
     )
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joulenap-frontend",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joulenap-frontend",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@codemirror/commands": "^6.11.0",
         "@codemirror/lang-yaml": "^6.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "joulenap-frontend",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/devStub.ts
+++ b/frontend/src/devStub.ts
@@ -823,11 +823,11 @@ function demoRoute(key: string, search: URLSearchParams, init?: RequestInit): un
     // The stub's "-stub" marker and its pending-update badge are dev affordances; a public
     // demo should look like a current, healthy install.
     case 'GET /health':
-      return { status: 'ok', version: '1.3.0' }
+      return { status: 'ok', version: '1.3.1' }
     case 'GET /update':
       return {
-        current: '1.3.0',
-        latest: '1.3.0',
+        current: '1.3.1',
+        latest: '1.3.1',
         update_available: false,
         url: 'https://github.com/Joulenap/joulenap/releases',
       }
@@ -1082,10 +1082,10 @@ const WIZARD_WOL_TEST: { sent: boolean; mac: string; broadcast: string } = {
 }
 
 const ROUTES: Record<string, unknown> = {
-  'GET /health': { status: 'ok', version: '1.3.0-stub' },
+  'GET /health': { status: 'ok', version: '1.3.1-stub' },
   'GET /update': {
-    current: '1.3.0-stub',
-    latest: '1.3.0',
+    current: '1.3.1-stub',
+    latest: '1.3.1',
     update_available: true,
     url: 'https://github.com/Joulenap/joulenap/releases',
   },


### PR DESCRIPTION
### Fixed

- A backup run is no longer marked failed when `vzdump` finished every guest but warned along
  the way. Proxmox VE ends such a task with the status `WARNINGS: n` rather than `OK`, and
  PVE 9 warns on every VM whose EFI disk does not yet carry the 2023 Microsoft certificates,
  so a route with a couple of UEFI guests was reported as failed, and notified as such, while
  every backup on the server was fine (#61). Joulenap now treats a warned task as a success,
  notes the warning count in the run timeline with a pointer to the task log, and still fails
  the source when a guest was actually lost: `vzdump` reports that as `job errors`, and a
  guest failure line in the log wins over the warning status either way. PBS sync tasks are
  unaffected: there `WARNINGS` means groups were not synced, and the run keeps failing.

Closes #61
